### PR TITLE
Enable C# Prism syntax highlighting

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -131,6 +131,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['csharp'],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Summary
- enable Prism to highlight C# code blocks by registering the language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da08e3fe4c83289d691cd2576add4e