### PR TITLE
docs: add configuration and template guides for Jsome

### DIFF
--- a/docs/Jsome/configuration.md
+++ b/docs/Jsome/configuration.md
@@ -1,0 +1,84 @@
+# Configuration files
+
+Jsome modifier files let you reshape the generated object graph without mutating incoming Swagger or JSON Schema sources. The configuration layer feeds into `CodeGenerator`, so the same schema can yield different DTO names, validation attributes, and enum handling simply by changing YAML or JSON inputs.
+
+## When to reach for configuration
+
+- Apply namespaces, name prefixes/suffixes, or enum defaults across an entire run.
+- Exclude or rename specific definitions and properties when upstream schemas cannot be altered.
+- Override validation ranges, required-ness, or regex patterns while keeping schema definitions canonical.
+- Attach richer descriptions and default values that flow directly into Handlebars templates and Swashbuckle metadata.
+
+## File layout
+
+Modifier files expose two top-level sections: `global` defaults and per-path `rules`. Paths are case-insensitive and use dotted notation (`Order.Customer.Email`). Wildcards such as `*.Id` are supported for broad tweaks; the CLI skips wildcard validation so you can apply them intentionally.
+
+```yaml title="config.yaml"
+# Global switches run before any template executes
+global:
+  namespace: "MyCompany.Api"           # Override the generated namespace/module
+  generateEnumTypes: true              # Promote integer enums to C# enum types
+  defaultInclude: true                 # Include everything unless a rule opts out
+  includeDescriptions: true            # Pass through OpenAPI description text
+  maxDepth: 10                         # Guard against recursive schemas
+  type_name_prefix: "Api"             # Prefix DTO/enum names (applied consistently)
+  type_name_suffix: "Dto"             # Suffix DTO/enum names for clarity
+
+# Focused overrides target classes or dotted property paths
+rules:
+  "User":
+    include: true                      # Force inclusion even if defaultInclude is false
+    description: "Authenticated profile returned from the identity service"
+  "User.email":
+    type: "EmailAddress"              # Custom type consumed by DTO templates
+    validation:
+      required: true                   # Promote to `required` keyword or [Required]
+      pattern: "^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$"
+      message: "Please enter a valid email"
+  "Order.items":
+    include: false                     # Drop noisy collections from the output graph
+```
+
+The generator resolves `rules` after schema parsing, so class-level directives cascade down to children unless a more specific rule overrides them.
+
+## Global settings reference
+
+| Setting | Description |
+| --- | --- |
+| `namespace` | Replaces the CLI-provided namespace; used whenever DTOs, validators, enums, or constants are created. |
+| `generateEnumTypes` | Enables enum and constants emission even if the CLI flag is unset. When `false`, the legacy string/integer properties remain. |
+| `defaultInclude` | Determines whether definitions are emitted when no explicit rule exists. Combine with targeted `include: false` entries to prune large schemas. |
+| `includeDescriptions` | Controls whether schema descriptions flow into templates; disable to keep generated XML docs minimal. |
+| `maxDepth` | Caps traversal depth while extracting nested objects to avoid runaway recursion in malformed specs. |
+| `type_name_prefix` / `type_name_suffix` | Applied by `ApplyTypeNameFormatting` so every DTO, enum, and constants class shares consistent naming. |
+
+## Property rules and validation overrides
+
+`PropertyRule` values let you opt out individual members (`include: false`), remap types (`type: Guid`), supply alternative descriptions, or set default literals. Nested `validation` blocks bubble into the FluentValidation templates, so `minLength`, `maxLength`, numeric `minimum`/`maximum`, and regular-expression `pattern` constraints translate directly into rule builders. Optional `message` strings give you friendly validation messages for UI display.
+
+If the schema already defines defaults or length hints, the configuration layer merges them. Explicit configuration always wins, and missing fields simply inherit the schema-provided values. Nullable handling and enum promotion still honour CLI switches—configuration supplements those decisions rather than replacing them entirely.
+
+## Loading and saving modifier files
+
+`ConfigurationLoader` handles format detection and serialization so you can check configuration artifacts into source control:
+
+- `Load`/`LoadAsync` infer YAML versus JSON by the file extension and surface clear exceptions for unsupported extensions, missing files, or invalid syntax.
+- `LoadFromYaml`/`LoadFromJson` accept raw strings and wrap parsing failures with actionable messages (ideal for unit tests or in-memory pipelines).
+- `SaveAsync`, `ToYaml`, and `ToJson` make it easy to persist generated configurations—for example, seeding a project with the generator’s defaults before applying manual edits.
+
+## Validating property paths
+
+Before code is emitted, `SchemaValidator.ValidatePropertyPaths` traverses the merged Swagger document to ensure every non-wildcard rule points at an actual definition/property. The CLI mirrors the Spectre.Console output used in tests: green ticks mean the configuration is aligned; red bullet points call out missing paths so you can fix typos before templates run. Because validation runs ahead of generation, you avoid accidentally skipping properties due to misnamed rules.
+
+## Applying configuration via CLI or APIs
+
+- Pass `--config config.yaml` (or `.yml`/`.json`) to `jsome generate` to load modifiers alongside your schema. Combine with `--yes` when running unattended pipelines that overwrite output folders.
+- Within custom tooling, set `CodeGenerationOptions.ModifierConfigurationPath` to load from disk or inject an in-memory object via `ModifierConfiguration` directly. When both are provided, the in-memory instance wins so tests can hydrate configurations without touching the filesystem.
+
+## Test coverage to lean on
+
+- `ConfigurationTests` round-trip YAML and JSON payloads through `ConfigurationLoader` to catch serialization regressions early.
+- `ModifierConfigurationIntegrationTests` feed real schemas plus configuration files through the generator to verify inclusion, renaming, and validation overrides.
+- `SchemaValidatorTests` assert that missing property paths are caught with the same messaging you see in the CLI, keeping the validation experience honest.
+
+Use these suites as guardrails whenever you introduce new modifiers or expand the configuration schema.

--- a/docs/Jsome/index.md
+++ b/docs/Jsome/index.md
@@ -1,76 +1,78 @@
 # Asynkron.Jsome
 
-Asynkron.Jsome is a .NET 8 code generator that ingests Swagger 2.0/OpenAPI documents or folders of JSON Schema files and emits strongly typed client artefacts. The public repository now exposes the full CLI, template set, and test suite, so you can study exactly how the generator produces C# DTOs, FluentValidation validators, Protocol Buffers schemas, optional F# modules, and TypeScript interfaces.
+Asynkron.Jsome is a .NET 8 global tool that turns Swagger 2.0/OpenAPI documents or directories full of JSON Schema files into strongly typed client artefacts. The open-source repository now includes the complete CLI, Handlebars template library, and test suite, so you can inspect exactly how DTOs, validators, Protocol Buffers schemas, F# modules, and TypeScript interfaces are produced.
+
+## Key capabilities at a glance
+
+- Generate idiomatic C# DTOs backed by either Newtonsoft.Json or System.Text.Json, with optional record types and Swashbuckle metadata.
+- Emit FluentValidation validators, enums/constants, Protocol Buffers `.proto` files, F# records/modules, and TypeScript interfaces from the same schema input.
+- Customise output with YAML/JSON configuration files, template overrides, and helper functions exposed by the CLI.
+- Validate schema and configuration mismatches up front with detailed Spectre.Console diagnostics driven by the included test harness.
 
 ## Install the CLI
 
-Install the global tool from NuGet (the package ID is `dotnet-jsome`):
+Install or update the NuGet global tool (`dotnet-jsome`) to put the `jsome` executable under `~/.dotnet/tools`:
 
 ```bash
-# Install or update the CLI
+# Install the latest CLI (requires .NET 8 runtime/SDK)
 dotnet tool install -g dotnet-jsome
+
+# Update an existing installation
 # dotnet tool update -g dotnet-jsome
 ```
 
-The installer drops the `jsome` command into `~/.dotnet/tools`. Add that directory to your `PATH` if the tool is not immediately available.
+After installation, ensure `~/.dotnet/tools` is on your `PATH` so your shell can resolve `jsome`.
 
-## Repository tour
-
-Clone `https://github.com/asynkron/Asynkron.Jsome` to inspect the source that backs the tool. The `src/Asynkron.Jsome` project contains the CLI entry point, JSON/Swagger models, configuration types, and built-in Handlebars templates, while `tests/Asynkron.Jsome.Tests` exercises the generator end to end with Roslyn compilation checks, locale edge cases, Protocol Buffers validation, and template overrides. The `testdata` and `schemas` folders hold larger specs (Stripe, OCPP) that mirror real-world usage when you want to experiment locally.
-
-## Generate C# from Swagger
-
-### Run the generator
-
-Point the CLI at a Swagger 2.0 JSON document (or omit it to fall back to the embedded Petstore sample) and choose an output folder:
+## Quick start workflow
 
 ```bash
+# 1. Generate from the embedded Petstore sample (no arguments required)
+jsome
+
+# 2. Target your own Swagger file and choose where artefacts are written
+jsome generate ./sample-swagger.json --output ./generated --namespace Sample.Generated
+
+# 3. Opt into modern records, System.Text.Json, Swashbuckle metadata, and Protocol Buffers
 jsome generate ./sample-swagger.json \
-  --output ./generated \
-  --namespace Sample.Generated \
-  --modern --records \
-  --system-text-json --swashbuckle-attributes \
-  --proto
+  --modern --records --system-text-json --swashbuckle-attributes \
+  --proto --output ./generated
 ```
 
-`Program.CreateGenerateCommand` wires up these switches via System.CommandLine, so the CLI prompts for confirmation unless `--yes` is supplied, validates mutually exclusive inputs (`swaggerFile` vs `--schema-dir`), and echoes a Spectre.Console summary of what will be produced. Running the command against the minimal `sample-swagger.json` below yields DTOs, validators, and Protocol Buffers definitions in the target directory.
+Behind the scenes `Program.CreateGenerateCommand` wires these switches via System.CommandLine, validates mutually exclusive inputs (for example `swaggerFile` versus `--schema-dir`), and displays a Spectre.Console summary before files are emitted. Add `--yes` to skip the confirmation prompt when overwriting an existing directory.
+
+### Sample input and generated C#
 
 ```json title="sample-swagger.json"
 {
   "swagger": "2.0",
   "info": { "title": "Sample API", "version": "1.0.0" },
-  "basePath": "/api",
-  "paths": {},
   "definitions": {
     "User": {
       "type": "object",
       "required": ["id", "name"],
       "properties": {
-        "id": { "type": "integer", "format": "int64" },
+        "id":   { "type": "integer", "format": "int64" },
         "name": { "type": "string" },
-        "email": { "type": "string", "format": "email" }
+        "email":{ "type": "string", "format": "email" }
       }
     }
   }
 }
 ```
 
-### Example C# output
-
-With `--modern --records --system-text-json --swashbuckle-attributes` enabled, the generated record includes nullable annotations, `JsonPropertyName` attributes, Spectre-enhanced validation error messages, and optional Swagger metadata—exactly what `SystemTextJsonTests` and `ModernCSharpFeaturesTests` assert in the open test suite.
-
-```csharp
+```csharp title="Generated record (modern C#)"
+// Attributes line up with System.Text.Json and Swashbuckle when the relevant flags are set
 [method: JsonConstructor]
 public partial record User(
     [property: JsonPropertyName("id")]
     [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     [property: SwaggerSchema(Format = "int64")]
     required long Id,
+
     [property: JsonPropertyName("name")]
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     [property: Required(AllowEmptyStrings = false)]
-    [property: StringLength(50, MinimumLength = 1)]
     required string Name,
+
     [property: JsonPropertyName("email")]
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [property: SwaggerSchema(Format = "email")]
@@ -78,96 +80,58 @@ public partial record User(
 );
 ```
 
-Protocol Buffers support is toggled via `--proto`. `CodeGenerator.GetTemplatesToLoad` automatically includes `proto.hbs`, `proto.enum.hbs`, and `proto.string_enum.hbs` when the flag is set, and `ProtoTemplateTests` verify that every DTO, numeric enum, and string enum is rendered with the correct scalars and snake_case field names.
+`ModernCSharpFeaturesTests`, `SystemTextJsonTests`, and `ProtoTemplateTests` in the public test suite cover the attribute placement, nullable annotations, and Protocol Buffers output so you can trust the generated artefacts stay consistent release to release.
 
-## Using configuration files
+## Consuming JSON Schema directories
 
-`ConfigurationLoader` accepts YAML or JSON and materialises a `ModifierConfiguration` object graph composed of `GlobalSettings`, `PropertyRule`, and nested `PropertyValidation` options. The snippet below mirrors the structure asserted in `ModifierConfigurationIntegrationTests`, where dotted property paths let you exclude DTOs, override types, and add custom validation rules.
-
-```yaml title="config.yaml"
-global:
-  namespace: "MyApi.Generated"
-  generateEnumTypes: true
-  type_name_prefix: "Api"
-  type_name_suffix: "Dto"
-
-rules:
-  "User.email":
-    validation:
-      required: true
-      pattern: "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$"
-      message: "Please enter a valid email"
-  "User.id":
-    description: "Primary key issued by the identity service"
-    format: int64
-  "Order":
-    include: false
-```
-
-* `global` tweaks namespaces, naming prefixes/suffixes, enum generation, and default inclusion—`ModifierConfiguration.IsIncluded` and `ApplyTypeNameFormatting` honour these settings while constructing DTOs.
-* `rules` target specific properties (case-insensitive) using dotted paths; wildcard paths such as `*.Id` are supported and intentionally skipped by `SchemaValidatorTests` when validating configuration safety.
-* `SchemaValidator.ValidatePropertyPaths` flags any rule pointing at a missing schema member before generation proceeds, surfacing friendly Spectre.Console messages instead of silently omitting fixes.
-
-Apply a config file by supplying `--config config.yaml`. Combine it with `--yes` to skip the interactive confirmation prompt `HandleGenerateCommand` displays whenever destructive overwrites are detected.
-
-## Working with Handlebars templates
-
-All artefacts are rendered through Handlebars templates stored in `src/Asynkron.Jsome/Templates`. Each template may contain a YAML front matter header that sets the extension or describes the output. `CodeGenerator` loads the required files, checks for missing assets, and exposes helpers like `proto_type`, `snake_case`, and `add` that are used across the built-in templates and surfaced to your custom templates.
-
-| Template | Description |
-| --- | --- |
-| `DTO.hbs` | Default C# class template with Newtonsoft.Json support and DataAnnotations |
-| `DTORecord.hbs` | Modern record template activated via `--records`, adding `[method: JsonConstructor]` and property-scoped attributes |
-| `Validator.hbs` | FluentValidation rules for each DTO, including numeric guards that `LocaleIssueTests` keep invariant-culture safe |
-| `Enum.hbs` / `Constants.hbs` | Optional enum/constant outputs controlled by configuration |
-| `proto.hbs`, `proto.enum.hbs`, `proto.string_enum.hbs` | Protocol Buffers templates loaded when `--proto` is set |
-| `FSharp.hbs`, `FSharpModule.hbs` | F# record and module templates with DataAnnotations and helper builders |
-| `TypeScript.hbs` | Optional interface and type guard template |
-
-To customise output you can point `--template-dir` at a folder of `.hbs` files or pass `--templates` with an explicit list. `CustomTemplateTests` exercise both approaches by rendering bespoke files alongside the built-in DTOs and validators.
-
-### Generating F# artefacts
-
-Pass the F# templates explicitly to produce both C# and F# output in one run:
+Supply `--schema-dir` to parse every `.json` schema under a folder:
 
 ```bash
-jsome generate ./sample-swagger.json \
-  --output ./generated \
-  --templates DTO.hbs Validator.hbs FSharp.hbs FSharpModule.hbs \
-  --namespace Sample.Generated --yes
+# Merge individual JSON Schema files into a single generation run
+jsome generate --schema-dir ./schemas --namespace Sample.Generated --output ./generated
 ```
 
-`FSharp.hbs` and `FSharpModule.hbs` include YAML headers (`description: …`) and emit idiomatic records with `[<JsonPropertyName>]` or `[<JsonProperty>]` attributes plus modules for validation helpers. `OcppV16IntegrationTests` confirm that nested types, array shapes, and validation metadata round-trip correctly when F# files are requested.
+`JsonSchemaParser.ParseDirectory` merges definitions, resolves `$ref` entries, and halts when conflicting shapes are discovered. The `JsonSchemaParserTests` and OCPP fixtures bundled with the repository demonstrate how large schema sets are handled safely.
 
-### Generating Protocol Buffers
+## Deep dives
 
-Toggle `--proto` to render `proto3` schemas next to the C# artefacts. The `proto` templates reuse the same `ClassInfo`, `EnumInfo`, and `ConstantsInfo` shapes produced for C#, so enum naming and snake_case conversions stay consistent. `ProtoTemplateTests` and `OcppV16ComplianceTests` assert that the emitted files compile under `buf lint` and respect OCPP 1.6 expectations.
+- Read the [configuration guide](configuration.md) to discover every YAML/JSON switch, validation hook, and CLI flag that shapes the generated object graph.
+- Explore [Handlebars template customization](templates.md) for frontmatter metadata, helper functions, and strategies for layering in your own outputs alongside the built-in DTO/validator set.
 
-### Rendering TypeScript interfaces
+## Command-line reference
 
-Because `TypeScript.hbs` is a normal Handlebars template you can opt into TypeScript output via `--templates` or by copying the template into a custom directory. The template emits `interface` declarations and runtime guards, and `CustomTemplateTests` show how to assert on the generated `.ts` content for your own templates.
+| Option | Description |
+| --- | --- |
+| `swagger-file` | Optional positional path; omit it to use the built-in Petstore sample. |
+| `--schema-dir <folder>` | Consume an entire directory of JSON Schema files. |
+| `--config <file>` | Apply YAML/JSON configuration overrides before generation. |
+| `--output <folder>` | Destination directory (omit to stream files to STDOUT). |
+| `--namespace <name>` | Override the root namespace/module for generated artefacts. |
+| `--modern` | Enable nullable reference types, `required` keyword, and modern annotations. |
+| `--records` | Emit C# records instead of classes (requires `--modern`). |
+| `--system-text-json` | Swap Newtonsoft.Json attributes for System.Text.Json equivalents. |
+| `--swashbuckle-attributes` | Add `SwaggerSchema` metadata for Swashbuckle integration. |
+| `--proto` | Emit Protocol Buffers templates alongside C#. |
+| `--templates <files...>` | Render an explicit list of template files. |
+| `--template-dir <folder>` | Load templates from a custom directory. |
+| `--yes` | Skip confirmation prompts when overwriting files. |
+| `--help` | Display detailed CLI usage information. |
 
-## Parsing sources beyond Swagger
+## Repository tour and tests
 
-Instead of providing a single Swagger document you can hand `--schema-dir` a directory full of JSON Schema files. `JsonSchemaParser.ParseDirectory` merges every `.json` file, honours schema titles, extracts internal `definitions`, resolves `$ref` entries, and refuses to continue when two files disagree about a definition. `JsonSchemaParserTests` cover duplicate handling, `$ref` validation, and conflict detection so CLI users receive actionable errors.
+Clone `https://github.com/asynkron/Asynkron.Jsome` to inspect the source that powers the tool:
 
-## What happens under the hood
+- `src/Asynkron.Jsome` hosts the CLI entry point (`Program`), `HandleGenerateCommand`, configuration types, template loader, and schema parsers.
+- `tests/Asynkron.Jsome.Tests` exposes the xUnit suite that exercises Roslyn compilation, locale edge cases, and template overrides. Fixtures such as `OcppV16IntegrationTests`, `ModernCSharpFeaturesTests`, `SystemTextJsonTests`, and `ProtoTemplateTests` map directly to the CLI switches described above.
+- `testdata` and `schemas` include larger, real-world API specifications (Stripe, OCPP 1.6) so you can experiment locally or extend coverage.
 
-The compiled assembly exposes a small set of focused types, making it easy to trace how input is transformed into code:
+Run the test suite to validate template or configuration changes:
 
-* `Program` wires up the System.CommandLine verbs, including options such as `--modern`, `--records`, `--system-text-json`, `--swashbuckle-attributes`, `--schema-dir`, `--templates`, and `--proto`, before dispatching to `HandleGenerateCommand` for validation and orchestration.
-* `ConfigurationLoader` deserialises YAML/JSON via YamlDotNet or Newtonsoft.Json, feeding a `ModifierConfiguration` tree built from `GlobalSettings`, `PropertyRule`, `PropertyValidation`, and `EnumMemberOverride` nodes that shape the generated models.
-* `SchemaValidator` walks Swagger definitions to warn about rules targeting missing properties so configuration mistakes are caught before generation; tests assert that wildcards are ignored and missing paths surface friendly messages.
-* `CodeGenerator` loads templates, registers Handlebars helpers, converts Swagger models into `ClassInfo`, `PropertyInfo`, `EnumInfo`, and `ConstantsInfo`, and materialises files through the selected templates. `CodeGenerationTests` and `CompilationValidationTests` prove the output compiles, respects `[Required]` logic, and keeps numeric validation culture-invariant.
-* Helper methods such as `ApplyModifierConfiguration`, `MapSwaggerTypeToCSharpType`, and `ExtractInlineNestedObjects` ensure naming consistency, nested schema flattening, and configuration overrides work for both DTOs and derived artefacts—a behaviour validated in `OcppV16IntegrationTests` and `SystemTextJsonTests`.
+```bash
+# Restore, build, and execute the published xUnit suite
+dotnet test
+```
 
-## Test suite highlights
+`CodeGenerationTests`, `CompilationValidationTests`, and `LocaleIssueTests` ensure that generated artefacts continue to compile, enforce validation rules, and respect invariant culture semantics. Use them as guardrails when customising templates or wiring in new output formats.
 
-The repository ships its full xUnit test harness. Running `dotnet test` exercises the scenarios below so you can confirm your own template/config changes stay compatible:
-
-* **Configuration validation** – `SchemaValidatorTests` and `ModifierConfigurationIntegrationTests` ensure invalid paths raise friendly errors, exclusions drop DTOs, and custom validation metadata appears in the generated validators.
-* **Language feature toggles** – `ModernCSharpFeaturesTests`, `SystemTextJsonTests`, and `CodeGenerationTests` cover `--modern`, `--records`, `--system-text-json`, and Swashbuckle attribute flags, preventing regressions in attribute placement or record syntax.
-* **Template outputs** – `ProtoTemplateTests`, `CustomTemplateTests`, and `CompilationValidationTests` assert that Protocol Buffers, bespoke templates, and compiled DTOs stay correct across releases.
-* **Real-world schemas** – `OcppV16IntegrationTests`, `OcppV16ComplianceTests`, and `JsonSchemaParserTests` load the bundled OCPP 1.6 and JSON Schema directories, stress testing nested objects, enums, and localisation edge cases (`LocaleIssueTests`).
-
-Grab the repo, run `dotnet tool install jsome`, and explore the templates or tests that match your scenario. The codebase is intentionally small and well-commented, making it straightforward to extend with new templates or configuration knobs now that everything is public.
+Grab the repo, install the tool, and iterate on templates or configs with confidence—the full pipeline from schema ingestion to generated code is transparent and covered by tests.

--- a/docs/Jsome/templates.md
+++ b/docs/Jsome/templates.md
@@ -1,0 +1,87 @@
+# Handlebars template customization
+
+Every artifact that Jsome emits flows through a Handlebars template. Understanding how templates are discovered, how frontmatter is parsed, and which helpers are available lets you extend the generator confidently—whether you are tweaking the default DTO output or layering in entirely new languages.
+
+## Template discovery order
+
+`CodeGenerator` resolves the template directory with a predictable search stack:
+
+1. Honour an explicit CLI `--template-dir` (or `CodeGenerationOptions.TemplateDirectory`). Missing folders trigger a clear `DirectoryNotFoundException` so you know the override failed.
+2. Fall back to the tool installation path (`<tool>/Templates`) and its NuGet `contentFiles` twin when running the global tool.
+3. During local development, walk upward from the current working directory until `src/Asynkron.Jsome/Templates` is found.
+4. Finally, look for a `Templates` folder beside the executable so ad-hoc experiments still work.
+
+If none of these locations exist, the CLI prints the attempted paths and exits, helping you supply the right directory without guesswork.
+
+## Standard template set
+
+Unless you specify custom files, the generator loads a curated set:
+
+- `DTO.hbs` for class-based C# DTOs (Newtonsoft.Json attributes).
+- `Validator.hbs` for FluentValidation rules.
+- `Enum.hbs` and `Constants.hbs` when enum support is enabled.
+- `DTORecord.hbs` when `--records` and `--modern` toggle record generation.
+- `proto.hbs`, `proto.enum.hbs`, and `proto.string_enum.hbs` when `--proto` is active.
+
+You can narrow the list with `--templates DTO.hbs Validator.hbs` (or `CodeGenerationOptions.CustomTemplateFiles`) to render only specific files. Supplying a list that omits required defaults results in friendly “No DTO template available” exceptions so you immediately notice missing artefacts.
+
+## Frontmatter and metadata
+
+Templates can declare metadata blocks to change file extensions or describe their purpose. `TemplateMetadata` strips the frontmatter before compilation and exposes the remaining content to Handlebars.
+
+```hbs title="proto.hbs"
+---
+extension: proto                  # Persist generated messages with a .proto extension
+description: Protocol Buffers DTOs
+---
+message {{ClassName}} {
+  // Use the `add` helper to increment field numbers from zero-based indexes
+  {{#each Properties}}
+  {{add @index 1}}: {{proto_type Type}} {{snake_case Name}} = {{add @index 1}};
+  {{/each}}
+}
+```
+
+Supported frontmatter keys today are `extension` and `description`; everything else passes through unchanged so you can add comments without affecting parsing.
+
+## Helpers you can rely on
+
+The generator registers a few helpers before compiling templates:
+
+- `add` — integer addition, ideal for zero-based `@index` arithmetic in Protocol Buffers.
+- `snake_case` — converts PascalCase or camelCase strings to snake_case.
+- `proto_type` — maps C# types (`int`, `Guid`, `List<string>`) into appropriate Protocol Buffers scalars or repeated clauses.
+
+Because helpers are registered globally, they work in both the built-in `.hbs` files and any custom templates you load from disk.
+
+## View models exposed to templates
+
+Each template receives strongly typed view models so you do not have to massage raw Swagger documents inside Handlebars:
+
+- `ClassInfo` supplies `ClassName`, `Namespace`, `Description`, feature toggles (`UseSystemTextJson`, `UseSwashbuckleAttributes`), and a `Properties` collection.
+- `PropertyInfo` includes PascalCase names, CLR `Type`, JSON property names, nullability flags, validation metadata (min/max lengths, regex patterns), enum wiring (`EnumTypeName`, `ConstantsClassName`), and Swashbuckle hints (`SwaggerSchemaDescription`, `SwaggerExample`).
+- `EnumInfo`/`EnumValueInfo` and `ConstantsInfo`/`ConstantInfo` describe generated enum members or string constant classes, including friendly descriptions you can surface in documentation comments.
+
+When you create additional templates, iterate over these structures rather than parsing the schema yourself—tests already guarantee their shape and invariants.
+
+## Custom directories and partial template sets
+
+To point the CLI at a different template root, call:
+
+```bash
+# Render with a bespoke template directory and opt into nullable records
+jsome generate ./specs/petstore.json \
+  --template-dir ./templates/csharp-records \
+  --templates DTORecord.hbs Validator.hbs \
+  --modern --records --system-text-json
+```
+
+Mixing built-in and custom files works too: the loader merges your list, then compiles each `TemplateMetadata.Content`. Missing files raise a consolidated error that lists every absent template so you can fix typos before rerunning.
+
+## Test harness for template changes
+
+- `CustomTemplateTests` ensures that pointing to alternate directories or partial file sets keeps generation resilient.
+- `CompilationValidationTests` compiles the emitted C# so template tweaks cannot silently break syntax.
+- `ProtoTemplateTests` verifies frontmatter extensions and helper usage for `.proto` output, making it safe to extend Protocol Buffers coverage.
+
+Running these suites after editing templates provides fast feedback that your Handlebars changes still play nicely with the wider generator.


### PR DESCRIPTION
## Summary
- add dedicated guides covering configuration files and Handlebars templates for Jsome
- link the Jsome landing page to the new deep-dive documentation for easier discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da16c49e348328b55eb215add6e166