### PR TITLE
docs: expand durable functions storage guidance

### DIFF
--- a/docs/DurableFunctions/storage.md
+++ b/docs/DurableFunctions/storage.md
@@ -5,7 +5,102 @@ sidebar_label: Storage backends
 
 # Storage backends
 
-Durable orchestrations need persistent state for the event history, timers, and orchestration metadata. The public repository includes ready-to-run examples for both SQLite and PostgreSQL.
+Durable orchestrations need persistent state for the event history, timers, and orchestration metadata. A storage provider is the durable runtime's source of truth: it accepts deterministic decisions from the orchestrator, persists them, and feeds ready work back to the worker loop. The public repository includes ready-to-run examples for both SQLite and PostgreSQL, but you can also bring your own implementation.
+
+```mermaid
+flowchart LR
+    subgraph Durable Runtime
+        poll[Poll ready states]
+        replay[Replay deterministic history]
+        commit[Commit new events]
+    end
+    subgraph Storage Provider
+        ready[(GetReadyStatesAsync)]
+        load[(GetStateAsync)]
+        save[(SaveStateAsync)]
+        purge[(RemoveStateAsync)]
+    end
+    poll --> ready
+    replay --> load
+    commit --> save
+    commit --> purge
+    style Storage Provider fill:#f3faff,stroke:#7bb3e8
+```
+
+## Provider responsibilities
+
+Every storage backend implements the `IStateStore` contract exposed by `Asynkron.DurableFunctions`. At a minimum it must:
+
+- Persist `DurableFunctionState` instances that contain the orchestration history, timers, and outstanding activities.
+- Return states that are due for execution via `GetReadyStatesAsync` so the runtime can resume orchestrators on schedule.
+- Support idempotent writes: orchestrator replays will retry the same `SaveStateAsync` payload until it succeeds.
+- Delete terminal instances when `RemoveStateAsync` is called or when automatic cleanup is enabled.
+
+### Writing a custom provider
+
+1. **Implement `IStateStore`.** Provide concrete implementations for `SaveStateAsync`, `GetStateAsync`, `GetReadyStatesAsync`, and `RemoveStateAsync`. The methods should use transactions so partial updates do not leak through during process crashes.
+2. **Register the provider.** Expose it through dependency injection so `DurableFunctionRuntime` can resolve it. In ASP.NET Core apps that usually means `services.AddSingleton<IStateStore, YourStore>();`.
+3. **Handle serialization.** The runtime serializes orchestration payloads to JSON. Store them using UTF-8 text or a binary column that preserves the JSON value verbatim.
+4. **Optimize ready-state queries.** Add indexes that support lookups by `ExecuteAfter`, `InstanceId`, and status flags so polling remains efficient under load.
+5. **Add migrations.** Ensure the schema exists at startup. The built-in providers run migrations when the store is constructed; mirror that behavior if your backend requires table creation.
+
+> Tip: start from the [`SqliteStateStore`](https://github.com/asynkron/Asynkron.DurableFunctions.Public/blob/main/src/Asynkron.DurableFunctions/Persistence/SqliteStateStore.cs) implementation to understand the minimal contract before layering on concurrency features.
+
+### Supporting multi-host concurrency
+
+When multiple workers share the same database you need optimistic concurrency in addition to the basic CRUD contract. Implement `IConcurrentStateStore`, which extends `IStateStore` with lease-aware operations, and host it with `ConcurrentDurableFunctionRuntime`.
+
+Key responsibilities include:
+
+- **Lease acquisition** via `TryClaimLeaseAsync` so only one host executes an instance at a time.
+- **Lease renewal** for long-running orchestrations with `RenewLeaseAsync`.
+- **Lease release** on completion or failure through `ReleaseLeaseAsync`.
+- **Claimable state queries** that ignore instances whose leases are still valid.
+
+The concurrent stores add `Version`, `LeaseOwner`, and `LeaseExpiresAt` columns to the `DurableFunctionStates` table and keep them in sync with each operation. Conflicts are expected: always retry when `TryClaimLeaseAsync` reports a version mismatch.
+
+## Lease-based coordination
+
+Leases guard against duplicate execution when multiple hosts poll the same backend. Each worker includes its unique host identifier when claiming a lease. The store atomically updates the row to include the owner, an expiry timestamp, and the next expected version. If the worker crashes or loses connectivity, the lease expires and another host can safely take over.
+
+```mermaid
+sequenceDiagram
+    participant Runtime as Worker A
+    participant Store as State Store
+    participant Rival as Worker B
+    Runtime->>Store: GetReadyStatesAsync()
+    Store-->>Runtime: Return claimable instances
+    Runtime->>Store: TryClaimLeaseAsync(instance, hostId)
+    alt Lease granted
+        Store-->>Runtime: LeaseClaimResult.Success(version+1)
+        Runtime->>Store: SaveStateAsync(updated state)
+    else Lease rejected
+        Store-->>Runtime: LeaseClaimResult.Conflict()
+        Runtime->>Runtime: Retry/Backoff
+    end
+    Note over Store,Rival: Expired lease makes instance visible again
+    Rival->>Store: TryClaimLeaseAsync(instance, hostId)
+    Store-->>Rival: LeaseClaimResult.Success(new version)
+```
+
+While an orchestration runs, the runtime renews the lease in the background to keep ownership alive.
+
+```mermaid
+sequenceDiagram
+    participant Runtime as Worker A
+    participant Store as State Store
+    participant Timer as Renewal timer
+    Runtime->>Store: TryClaimLeaseAsync(instance)
+    Store-->>Runtime: LeaseClaimResult.Success(expiry = now+TTL)
+    loop Every TTL/2
+        Timer->>Runtime: Renew lease
+        Runtime->>Store: RenewLeaseAsync(instance, hostId)
+        Store-->>Runtime: LeaseClaimResult.Success(new expiry)
+    end
+    Note over Runtime,Store: If renewal fails or host stops, lease expires automatically
+```
+
+When renewal fails due to a version conflict, the runtime stops processing the instance and lets another worker claim it after the expiry window.
 
 ## SQLite
 


### PR DESCRIPTION
## Summary
- expand the storage backends overview with a runtime-to-provider flow diagram
- document the responsibilities for custom state store providers and how to register them
- explain the lease-based concurrency mechanism with diagrams for claiming and renewing leases

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da1eabfdf4832889faa20597359200