### PR TITLE
Add multi-host diagrams to operating at scale guide

### DIFF
--- a/docs/DurableFunctions/operations.md
+++ b/docs/DurableFunctions/operations.md
@@ -11,6 +11,34 @@ Durable workflows are stateful by design. Keep the following practices in mind w
 
 The concurrency subsystem guarantees that only one host executes a given instance at a time.
 
+The diagram below shows two workers racing for the same orchestration instance. Only the worker that successfully updates the
+lease metadata (`Version`, `LeaseOwner`, and `LeaseExpiresAt`) is allowed to continue replaying and committing history. The
+other worker backs off and looks for the next claimable instance.
+
+```mermaid
+sequenceDiagram
+    participant WorkerA as Worker A
+    participant Store as State store
+    participant WorkerB as Worker B
+    WorkerA->>Store: GetReadyStatesAsync()
+    Store-->>WorkerA: Return instance X
+    WorkerB->>Store: GetReadyStatesAsync()
+    Store-->>WorkerB: Return instance X
+    WorkerA->>Store: TryClaimLeaseAsync(X, hostA)
+    alt Lease succeeds
+        Store-->>WorkerA: LeaseClaimResult.Success
+        WorkerA->>Store: SaveStateAsync(updated history)
+        WorkerB->>Store: TryClaimLeaseAsync(X, hostB)
+        Store-->>WorkerB: LeaseClaimResult.Conflict
+        WorkerB->>WorkerB: Retry after delay
+    else Lease rejected
+        Store-->>WorkerA: LeaseClaimResult.Conflict
+        WorkerA->>WorkerA: Retry after delay
+    end
+    Note over WorkerA,Store: Lease renewal keeps hostA's ownership alive
+    Note over WorkerB,Store: Instance X is invisible to Worker B until the lease expires
+```
+
 - **Claim** – hosts atomically claim work by updating the `Version`, `LeaseOwner`, and `LeaseExpiresAt` columns. The compare-and-swap logic prevents duplicate execution.
 - **Renew** – long-running orchestrations renew their lease halfway through the lease window. If the process crashes the lease simply expires and another host claims the work.
 - **Release** – leases are cleared on completion, failure, or termination so the instance can be archived immediately.
@@ -22,6 +50,32 @@ Tune `LeaseTimeout` and `LeaseRenewalInterval` in configuration to balance failo
 - **Multiple workers** – use `ConcurrentDurableFunctionRuntime` plus a shared relational store (SQLite with WAL or PostgreSQL) so hosts coordinate safely.
 - **Throughput** – increase `MaxConcurrentOrchestrations` gradually. Combine with rate limiting on downstream services to avoid overload.
 - **Polling** – the runtime polls storage for new work. Observe storage metrics before lowering the `PollingInterval`.
+
+```mermaid
+flowchart LR
+    subgraph Host A
+        runtimeA[Concurrent Durable Runtime]
+        leaseA[Lease renewer]
+    end
+    subgraph Host B
+        runtimeB[Concurrent Durable Runtime]
+        leaseB[Lease renewer]
+    end
+    subgraph Host C
+        runtimeC[Concurrent Durable Runtime]
+        leaseC[Lease renewer]
+    end
+    store[(Shared state store)]
+    runtimeA -- poll & commit --> store
+    runtimeB -- poll & commit --> store
+    runtimeC -- poll & commit --> store
+    store -- ready instances --> runtimeA
+    store -- ready instances --> runtimeB
+    store -- ready instances --> runtimeC
+    classDef host fill:#f3faff,stroke:#7bb3e8,color:#0b3d70;
+    class runtimeA,leaseA,runtimeB,leaseB,runtimeC,leaseC host;
+    Note over Host A,Host C: Each host has a distinct identity for leases and health checks
+```
 
 ## Health monitoring
 


### PR DESCRIPTION
## Summary
- add a lease acquisition sequence diagram to highlight multi-host safety mechanics
- include a scaling overview diagram that shows multiple workers sharing the same state store

## Testing
- not run (docs change only)


------
https://chatgpt.com/codex/tasks/task_e_68da4183d7f88328848cb4f02d0b934a