### PR TITLE
Add syntax highlighting to blog code blocks

### DIFF
--- a/blog/2008-04-17-disposer-idisposable-and-template-pattern/index.md
+++ b/blog/2008-04-17-disposer-idisposable-and-template-pattern/index.md
@@ -11,7 +11,7 @@ But I also use template or factory methods alot in my apps, and that doesnt wor
 
 Imagine something like this:
 
-```
+```csharp
 public abstract class MyRendererBase
 {
       public void Render(Graphics g)
@@ -32,7 +32,7 @@ public abstract class MyRendererBase
 What could go wrong here?  
 Well, lets say that you implement the class like this:
 
-```
+```csharp
 public class SomeRenderer : MyRendererBase
 {
       public override Brush GetBackgroundBrush()
@@ -55,7 +55,7 @@ But if we do so, we would lose the benefits of template/factory methods, that is
 
 So my solution to this problem is to make  wrapper class that will hold a ref to the disposable object, and you can tell the wrapper if it should dispose the resource or not:
 
-```
+```csharp
 public class Disposer<T> : IDisposable where T : IDisposable
 {
     public T Value { get; set; }
@@ -92,7 +92,7 @@ public class Disposer<T> : IDisposable where T : IDisposable
 
 Once we have this class, we can alter our sample code to:
 
-```
+```csharp
 public abstract class MyRendererBase
 {
       public void Render(Graphics g)
@@ -114,7 +114,7 @@ public abstract class MyRendererBase
 
 And the implementation to:
 
-```
+```csharp
 public class SomeRenderer : MyRendererBase
 {
       public override Disposer<Brush> GetBackgroundBrush()

--- a/blog/2008-05-10-followup-how-to-validate-a-methods-arguments/index.md
+++ b/blog/2008-05-10-followup-how-to-validate-a-methods-arguments/index.md
@@ -20,7 +20,7 @@ A fulent API will let us read and write the requirements just like a specificati
 
 **Here is an example of the consumer:**
 
-```
+```csharp
 public static void MyMethod(string someArg,int someOtherArg)
 {
     someArg.RequireArgument("someArg")
@@ -48,7 +48,7 @@ But enough talking, here is the required code to accomplish this:
 
 **The implementation of the Validation\<T\> class:**
 
-```
+```csharp
 public class Validation<T>
 {
     public T Value { get; set; }
@@ -63,7 +63,7 @@ public class Validation<T>
 
 **The implementation of the Require method:**
 
-```
+```csharp
 public static class Extensions
 {
     public static Validation<T> RequireArgument<T>(this T item, string argName)
@@ -75,7 +75,7 @@ public static class Extensions
 
 **And the implementation of the different validation methods:**
 
-```
+```csharp
 public static class ValidationExtender
 {
     [DebuggerHidden]

--- a/blog/2008-05-28-argument-validation-framework-released/index.md
+++ b/blog/2008-05-28-argument-validation-framework-released/index.md
@@ -37,7 +37,7 @@ A generic numeric type that supports math operations.
 
 **Validation pre conditions:**
 
-```
+```csharp
 static string ValidationFunc(int a,string b,DateTime c)
 {
   //pre conditions:
@@ -57,7 +57,7 @@ static string ValidationFunc(int a,string b,DateTime c)
 
 **Validation post conditions:**
 
-```
+```csharp
 string res = "Foo";
 //post condition:
 return res.Require("res")
@@ -68,7 +68,7 @@ return res.Require("res")
 
 **Async fork:**
 
-```
+```csharp
 static int ForkIt()
 {
    int a = 0;
@@ -86,7 +86,7 @@ static int ForkIt()
 
 **Flextensions:**
 
-```
+```csharp
 //fluent casts, no need to wrap in ((int)var).
 someVar.Cast<Foo>().Bar();
 someVar.As<Boo>().Yoo();

--- a/blog/2008-06-04-net-stateful-delegates-and-memoization/index.md
+++ b/blog/2008-06-04-net-stateful-delegates-and-memoization/index.md
@@ -15,7 +15,7 @@ If you create an anonymous delegate inside a factory method, you can infact give
 
 **Example:**
 
-```
+```csharp
 static Func<int> CreateCounter() 
 {
      int i = 0; //bind delegate to a local mutable variable 
@@ -28,7 +28,7 @@ static Func<int> CreateCounter()
 
 By using this method we can now create a stateful delegate:
 
-```
+```csharp
 var myCounter = CreateCounter(); 
 Console.WriteLine( myCounter() ); //prints : 0 
 Console.WriteLine( myCounter() ); //prints : 1 
@@ -52,7 +52,7 @@ We can create memoizations in C# by exploiting the fact that anonymous delegates
 
 **Example:**
 
-```
+```csharp
 static Func<T1, T2, TResult> CreateMemo
     <T1, T2, TResult>(Func<T1, T2, TResult> source)
 {

--- a/blog/2008-11-03-linq-expressions-assign-private-fields-c-4/index.md
+++ b/blog/2008-11-03-linq-expressions-assign-private-fields-c-4/index.md
@@ -14,7 +14,7 @@ Since my old post [“Linq Expressions: Access private fields”](http://rogeral
 
 So here it is, the code for assigning private fields using pure Linq Expressions:
 
-```
+```csharp
 public static Action<T, I> GetFieldAssigner<T, I>(string fieldName)
 {
 
@@ -41,7 +41,7 @@ The code works pretty much the same way that my old field reader did except that
 
 Some sample usage code:
 
-```
+```csharp
 Person roger = .....
 var assigner = GetFieldAssigner<Person,string>("firstName");
 assigner(roger, "Roggan");

--- a/blog/2008-11-22-linqing-mgrammar-to-cil/index.md
+++ b/blog/2008-11-22-linqing-mgrammar-to-cil/index.md
@@ -56,7 +56,7 @@ Linq.Expressions is not really new in .NET 4, but they have been greatly extende
 
 **Variables:**
 
-```
+```text
 string myString = "hello world"
 int myInteger = 123
 decimal myDecimal = 123.456
@@ -65,7 +65,7 @@ bool myBool = true
 
 **Expressions:**
 
-```
+```text
 int myInteger = 1+2*3-x*(y+3)
 string myString = "hello " + name + "!"
 bool myBool = x < y
@@ -74,14 +74,14 @@ string conversion = '1 + 2 = ' + (string) (1 + 2)
 
 **User interaction:**
 
-```
+```text
 string name = input
 print name
 ```
 
 **Loops and conditions:**
 
-```
+```text
 for int i = 1 to 10
 print i
 next

--- a/blog/2008-12-09-genetic-programming-mona-lisa-faq/index.md
+++ b/blog/2008-12-09-genetic-programming-mona-lisa-faq/index.md
@@ -28,7 +28,7 @@ Even if the population is small, there is still competition between the parent a
 
 Sample:
 
-```
+```text
 Drawing
 
     DrawPolygon (
@@ -56,7 +56,7 @@ A\) The fitness function is a pixel by pixel compare where the fitness for each 
 
 Pseudo Sample:
 
-```
+```text
 double fitness = 0
 for y = 0 to width
     for x = 0 to height

--- a/blog/2008-12-29-boolean-logic-and-intentions/index.md
+++ b/blog/2008-12-29-boolean-logic-and-intentions/index.md
@@ -11,7 +11,7 @@ Boolean logic
 I’ve seen quite a few blog and forum posts about how developers “abuse” boolean logic.  
 The most common of these examples would probably be something like:
 
-```
+```csharp
 bool userIsAuthenticated = Foo || Bar;
 if (userIsAuthenticated)
 {
@@ -25,14 +25,14 @@ else
 
 And people are arguing about how bad that is and that it can be shortened down to:
 
-```
+```csharp
 bool userIsAuthenticated = Foo || Bar;
 return userIsAuthenticated;
 ```
 
 And then the next guy comes along and says it can be shortened down even more to:
 
-```
+```csharp
 return Foo || Bar;
 ```
 
@@ -58,7 +58,7 @@ e.g. Special logging messages when the result is true.
 
 And I have to say that the same goes for:
 
-```
+```bash
 if ( Foo == false )
 ```
 

--- a/blog/2009-01-06-i-thought-i-knew-c/index.md
+++ b/blog/2009-01-06-i-thought-i-knew-c/index.md
@@ -12,11 +12,11 @@ But apparently there are features that I haven’t known about.
 
 The first one is covariance on arrays in C#
 
-```
+```csharp
 string[] strings = new[]{"Hello","Covariance"};
 
 //assign the string array to an object array
-object[] objects = strings; 
+object[] objects = strings;
 
 objects[0] = "Hi"; //OK
 objects[1] = 123; //runtime exception
@@ -30,7 +30,7 @@ Also note the last line, we got dynamic type checks in C# , ewwww 😉
 
 Another feature I didn’t know about is this:
 
-```
+```csharp
 this = new Foo();
 ```
 

--- a/blog/2009-03-18-an-intentional-extensible-language/index.md
+++ b/blog/2009-03-18-an-intentional-extensible-language/index.md
@@ -13,7 +13,7 @@ I have never seen any other language that can do this.
 For those of you who don’t know what I’m talking about;  
 Pseudo lisp:
 
-```
+```text
  (foreach
       (item list
             (print item)))
@@ -36,7 +36,7 @@ A chain expression consists of;
 
 This allows you to write expressions like this:
 
-```
+```csharp
 //single symbol expression
 break; 
 
@@ -56,7 +56,7 @@ But what about that semi colon at the end of the “if” block?
 The semi colon represents the end of a chain of chain expressions.  
 My grammar allows me to link multiple chain expressions together, like this;
 
-```
+```csharp
 if(foo)
 {
  print ("foo is true");
@@ -79,7 +79,7 @@ and a reference to the “next” expression, that is, the “else if” express
 
 If we try to express the Lisp example at the top of the post using this grammar it would look something like this:
 
-```
+```csharp
 foreach item in list
 {
        print (item);

--- a/blog/2009-03-23-linq-expressions-from-and-to-delegates/index.md
+++ b/blog/2009-03-23-linq-expressions-from-and-to-delegates/index.md
@@ -13,7 +13,7 @@ I’m getting quite a few hits on my blog regarding Linq Expressions and how to 
 This is not really possible, you can never cast or convert an existing delegate into an expression tree.  
 You can however assign lambda expressions to expression trees exactly the same way as you assign them to a delegate.
 
-```
+```csharp
 //assign a lambda expression to a delegate
 Func<int> myDelegate = () => 1 + 2 + a +b;
 
@@ -32,7 +32,7 @@ While the expression tree version will complile the expression into code that bu
 
 You can also pass lambda expressions exactly the same way;
 
-```
+```csharp
 //pass a lambda expression as a delegate
 
 Foo( () => 1 + 2 + a +b );
@@ -67,7 +67,7 @@ Linq expression can not be casted or converted into delegates, they can however 
 
 eg:
 
-```
+```csharp
 //create an linq expression
 Expression<Func<int>> myExpressionTree = () => 1 + 2 + a +b;
 

--- a/blog/2009-05-07-the-simplest-form-of-configurable-dependency-injection/index.md
+++ b/blog/2009-05-07-the-simplest-form-of-configurable-dependency-injection/index.md
@@ -31,7 +31,7 @@ at the same time achive the pluggability of instance methods (or rather of diffe
 
 Here is some sample code:
 
-```
+```csharp
 
 //The Class that you use to get your objects
 public static class Config
@@ -72,7 +72,7 @@ This allows me to assign new implementations to that static field if I want to, 
 
 My code can then consume the factory like this:
 
-```
+```csharp
 IDbCommand cmd = Config.GetCommand();
 ```
 
@@ -80,13 +80,13 @@ That looks quite OK, doesn’t it?
 
 And in order to change the implementation for some resolve method:
 
-```
+```csharp
 Config.GetCommand = () => new MySpecialCommand();
 ```
 
 Or if you like the old delegate syntax:
 
-```
+```csharp
 Config.GetCommand = delegate
                     {
                         return new MySpecialCommand();

--- a/blog/2009-05-11-pleasing-the-or-mapper-default-constructor-hack/index.md
+++ b/blog/2009-05-11-pleasing-the-or-mapper-default-constructor-hack/index.md
@@ -15,7 +15,7 @@ However, if you intend to expose an entity that only support a copy constructor.
 
 Let’s say for the sake of the argument that we have an immutable “Order” class, that can only be created by passing an “OrderRequest”:
 
-```
+```csharp
 public class Order
 {
    public Order( OrderRequest request )
@@ -46,7 +46,7 @@ You can provide a default constructor and mark it with the “Obsolete” attrib
 This can prevent your code from calling the constructor while allowing the mapper framework to create the entities through reflection (which most POCO mappers already do).  
 You can even separate out this hack code from the actual entity using partial classes:
 
-```
+```csharp
 public partial class Order
 {
    public Order( OrderRequest request )

--- a/blog/2009-05-21-entity-framework-4-immutable-value-objects/index.md
+++ b/blog/2009-05-21-entity-framework-4-immutable-value-objects/index.md
@@ -10,7 +10,7 @@ Ok, the title is not quire accurate, I’m not aware of any way to accomplish tr
 
 However, this is a quite nice attempt IMO:
 
-```
+```csharp
     public class Address
     {
         //Private setters to avoid external changes

--- a/blog/2009-05-21-entity-framework-4-where-entity-id-in-array/index.md
+++ b/blog/2009-05-21-entity-framework-4-where-entity-id-in-array/index.md
@@ -8,7 +8,7 @@ Here is a little trick if you want to issue a query to the database and select a
 
 <!-- truncate -->
 
-```
+```csharp
 //assemble an array of ID values
 int[] customerIds= new int[] { 1, 2, 3 };
 

--- a/blog/2009-05-22-entity-framework-4-managing-inverse-properties/index.md
+++ b/blog/2009-05-22-entity-framework-4-managing-inverse-properties/index.md
@@ -30,7 +30,7 @@ We can design our entities like this:
 
 **OrderDetail:**
 
-```
+```csharp
 public class OrderDetail
 {
     ...properties...
@@ -48,7 +48,7 @@ public class OrderDetail
 
 **Order:**
 
-```
+```csharp
 public class Order
 {
     ...properties...

--- a/blog/2009-05-24-entity-framework-4-using-eager-loading/index.md
+++ b/blog/2009-05-24-entity-framework-4-using-eager-loading/index.md
@@ -29,7 +29,7 @@ I always use eager loading on my aggregates, so I want a simple way to tell my E
 
 Here is how I create my exstension methods for loading complete aggregates:
 
-```
+```csharp
 public static class ContextExtensions
 {
   public static ObjectQuery<Order> 
@@ -47,7 +47,7 @@ This makes it possible to use the load spans directly on my context without addi
 
 This way, you can now issue a query using load spans like this:
 
-```
+```csharp
 var orders = from order in context.OrderSet.AsOrderAggregate()
              select order;
 ```

--- a/blog/2009-05-30-entity-framework-4-entity-dependency-injection/index.md
+++ b/blog/2009-05-30-entity-framework-4-entity-dependency-injection/index.md
@@ -14,7 +14,7 @@ But when it comes to Lazy Load, we can no longer do this, in this case we need t
 
 If you are aiming to use Entity Framework 4 once it is released, you can accomplish this with the following code snippet:
 
-```
+```csharp
 
 ..inside your own EF container class..
 

--- a/blog/2009-11-21-linq-to-sql-dynamic-where-clause/index.md
+++ b/blog/2009-11-21-linq-to-sql-dynamic-where-clause/index.md
@@ -15,7 +15,7 @@ Let’s say we need to implement a search method with the following signature:
 If the requirement is that you should be able to pass zero to three arguments to this method and only apply a “where” criteria for the arguments that are not null.  
 Then we can use the following code to make it work: 
 
-```
+```csharp
 IList<Customer> FindCustomers(string name,string contactName,string city)
 {
      var query = context.Cutomers;

--- a/blog/2009-11-21-linq-to-sql-poco-and-value-objects/index.md
+++ b/blog/2009-11-21-linq-to-sql-poco-and-value-objects/index.md
@@ -15,7 +15,7 @@ By treating it as a DAL we can manually handle the data to object transformation
 If we for example want to fetch a list of POCO Customers that also have an immutable Address value object associated to them,  
 we could use the following code to accomplish this:
 
-```
+```csharp
 //Poco prefix only used to distinguish between l2s and poco entities here
 IList<Customer> FindCustomers(string name)
 {

--- a/blog/2009-12-27-f-pipelining-in-c/index.md
+++ b/blog/2009-12-27-f-pipelining-in-c/index.md
@@ -13,7 +13,7 @@ Here is one such example where F# developers try to make it look like F# can do 
 **F# code  **
 F# code that apparently is much easier to read than C# code:
 
-```
+```fsharp
 HttpGet "http://www-static.cc.gatech.edu/classes/cs2360_98_summer/hw1"
 |> fun s -> Regex.Replace(s, "[^A-Za-z']", " ")
 |> fun s -> Regex.Split(s, " +")
@@ -25,7 +25,7 @@ HttpGet "http://www-static.cc.gatech.edu/classes/cs2360_98_summer/hw1"
 **C# code  **
 My attempt to accomplish the same in C#.
 
-```
+```csharp
 HttpGet("http://www-static.cc.gatech.edu/classes/cs2360_98_summer/hw1")
     .Transform(s => Regex.Replace(s, "[^A-Za-z']", " "))
     .Transform(s => Regex.Split(s, " +"))
@@ -42,7 +42,7 @@ OK, I cheated, “Transform”,”Process” and “Execute” does not exist ou
 You would have to write those extension methods yourself.  
 However, they are reusable and fits nicely into a util lib.
 
-```
+```csharp
 public static class Extensions
 {
     public static TOut Transform<TIn, TOut>(this TIn self, Func<TIn, TOut> selector)

--- a/blog/2009-12-27-i-still-dont-get-f/index.md
+++ b/blog/2009-12-27-i-still-dont-get-f/index.md
@@ -11,7 +11,7 @@ I think that Microsoft are trying to sell F# to us as something new and awesome,
 **But F# can do function currying!**  
 Well, so can C#.
 
-```
+```csharp
 string Foo(int a,bool b)
 {
     //do stuff
@@ -29,7 +29,7 @@ void UseCurry()
 **F# can do pipelining!**  
 Well, so can C#
 
-```
+```csharp
 
 var listOfInts = new List<int> {1,2,3,4,5,6};
 Func<int,int> squared = x => x*x;

--- a/blog/2009-12-29-massive-parallelism-f-in-the-cloud/index.md
+++ b/blog/2009-12-29-massive-parallelism-f-in-the-cloud/index.md
@@ -11,7 +11,7 @@ Since F# supports quotations (for you C# devs, think Linq Expressions on roids) 
 
 Imagine the following code for a fractal calculation:
 
-```
+```fsharp
 for y = 0 to 100000 do
     CloudExec(
             <@

--- a/blog/2010-01-23-rx-framework-building-a-message-bus/index.md
+++ b/blog/2010-01-23-rx-framework-building-a-message-bus/index.md
@@ -13,7 +13,7 @@ Just check this out:
 
 **Our in proc message bus:**
 
-```
+```csharp
 public class MiniVan
 {
     private Subject<object> messageSubject = new Subject<object>();
@@ -35,7 +35,7 @@ public class MiniVan
 
 **Subscribing to messages:**
 
-```
+```csharp
 bus.AsObservable<MyMessage>()
     .Do(m => Console.WriteLine(m))
     .Subscribe();

--- a/blog/2010-03-23-generic-dsl-grammar-and-parser/index.md
+++ b/blog/2010-03-23-generic-dsl-grammar-and-parser/index.md
@@ -28,7 +28,7 @@ The downside of XML based DSLs is that they are extremely hard to read and edit
 Let’s say for the sake of the argument that we want to define some custom business pricing rules.  
 Using XML that could look something like:
 
-```
+```xml
 <rules>
    <rule product="50050" >
       <condition>
@@ -54,7 +54,7 @@ Such XML rule definition can easily bloat from something fairly simple to someth
 
 Using the generic DSL grammar that I have created, the above rules would look something like this:
 
-```
+```csharp
 product 50050
 {
     when (quantity > 200) then (20 - quantity / bonus);
@@ -65,7 +65,7 @@ product 50050
 
 Or you could use it to define Google protobuffer messages:
 
-```
+```csharp
 message OrderPlaced
 {
  1 Guid MessageId;
@@ -77,7 +77,7 @@ message OrderPlaced
 
 Or what about defining some CQRS entity definitions?
 
-```
+```csharp
 public entity Customer
 {
     private string Name;

--- a/blog/2010-04-01-genetic-programming-evolving-domain-logic-ala-cqrs/index.md
+++ b/blog/2010-04-01-genetic-programming-evolving-domain-logic-ala-cqrs/index.md
@@ -31,14 +31,14 @@ Example.
 
 Given that:
 
-```
+```csharp
 Customer.Rename("Foo");
 UoW.Commit();
 ```
 
 Expect:
 
-```
+```text
 CustomerRenamedEvent
   CustomerId = 123
   NewName = "Foo"
@@ -46,14 +46,14 @@ CustomerRenamedEvent
 
 Given that:
 
-```
+```csharp
 Customer.Rename("Bar");
 UoW.Commit();
 ```
 
 Expect:
 
-```
+```text
 CustomerRenamedEvent
   CustomerId = 345
   NewName = "Bar"
@@ -63,7 +63,7 @@ Or preferably a more complex scenario
 
 Given that:
 
-```
+```csharp
 Customer
  .NewOrder()
  .AddProduct(50050,10)
@@ -74,7 +74,7 @@ UoW.Commit();
 
 Expect:
 
-```
+```text
 OrderPlacedEvent
   OrderId = 1
   CustomerId = 2
@@ -106,7 +106,7 @@ A very nice benefit of evolution is that if you later get some changed requireme
 Since the fitness factor currently doesn’t include how complex the generated code is, the output can be somewhat verbose.  
 Actual sample:
 
-```
+```csharp
 public void Rename(string newName)
 {
      this.Name = (newName + "a¤").Substring(0, newName.Length - 9 + 5 + 4);

--- a/blog/2010-04-14-playing-with-plastic/index.md
+++ b/blog/2010-04-14-playing-with-plastic/index.md
@@ -27,7 +27,7 @@ With these 250 lines of code, I get features like:
 
 **Macro like functions:**
 
-```
+```csharp
 func for(ref init,ref cond,ref step,ref body)
 {
     init();
@@ -53,7 +53,7 @@ The macro like support allows me to add new constructs to the language, unlike o
 like Boo or Ruby where you can pass closures as the last argument to a function, I can pass an entire chain of functions or expressions as the tail argument.  
 thus allowing constructs like:
 
-```
+```csharp
 if(x)
 {
 }
@@ -70,7 +70,7 @@ This is the reason I picked the somewhat corny name “Plastic” for the langua
 
 **Passing functions:**
 
-```
+```csharp
 //passing functions
 func f(x)
 {
@@ -87,7 +87,7 @@ print (g(f,7));
 
 **Returning functions(closures):**
 
-```
+```csharp
 func makefun()
 {
     let x = 10;

--- a/blog/2010-04-15-plastic-added-generator-support/index.md
+++ b/blog/2010-04-15-plastic-added-generator-support/index.md
@@ -15,7 +15,7 @@ It’s so brilliant, no AST transformations and I could implement the whole thin
 
 This enables me to write code like this:
 
-```
+```csharp
 //a generator function
 func Range(low,high)
 {

--- a/blog/2010-04-17-more-on-plastic/index.md
+++ b/blog/2010-04-17-more-on-plastic/index.md
@@ -13,7 +13,7 @@ This is now used for generators.
 Yield is no longer a core function, instead, each generator takes a closure as its last argument which is then supplied by the foreach function.  
 This way the foreach body don’t have to be stored as a symbol, it is just passed as an argument to the generator.
 
-```
+```csharp
 func Range(low,high,yield)
 {
     for(let i=low,i<=high,i++)
@@ -46,7 +46,7 @@ Before, a break would only exit the most inner loop of the generator.
 
 Now I can do things like this:
 
-```
+```csharp
 func primes(low,high,yield)
 {    
     foreach(i in range(low,high))   

--- a/blog/2010-06-17-plasic-language-take-2/index.md
+++ b/blog/2010-06-17-plasic-language-take-2/index.md
@@ -18,7 +18,7 @@ Instead of chaining calls syntactically, I could instead chain them by passing t
 
 In my first attempt in plastic, the syntax would be:
 
-```
+```text
 if (condition)
 {
    ...body...
@@ -37,7 +37,7 @@ The “else” function would be a special function that requires a “last valu
 
 Like this:
 
-```
+```text
 if (condition) //if condition fails, return "fail"
 {
    ...body...
@@ -52,7 +52,7 @@ This way, the else function would have two arguments, the last result and a clos
 
 The else function would be implemented like this:
 
-```
+```csharp
 func else (lastresult,body)
 {
   let result = lastresult;

--- a/blog/2010-11-10-entity-framework-4-enum-support-in-linq/index.md
+++ b/blog/2010-11-10-entity-framework-4-enum-support-in-linq/index.md
@@ -20,7 +20,7 @@ For me this solution is good enough, I can make the integer property private and
 
 Example
 
-```
+```csharp
 public class Order
 {
      //this is the backing integer property that is mapped to the database
@@ -43,7 +43,7 @@ So how do we get our linq queries to translate from the enum property to the in
 
 The solution is far simpler that I first thought, using the new ExpressionVisitor base class I can use the following code to make it all work:
 
-```
+```csharp
 namespace Alsing.Data.EntityFrameworkExtensions
 {
     public static class ObjectSetEnumExtensions
@@ -105,7 +105,7 @@ The second class is the actual Linq Expression rewriter.
 
 By including this and adding the appropriate using clause to your code, you can now make queries like this:
 
-```
+```csharp
 var cancelledOrders = myContainer.Orders.Where(order => order.Status == OrderStatus.Cancelled).ToList();
 ```
 

--- a/blog/2011-02-28-linq-to-sqlxml/index.md
+++ b/blog/2011-02-28-linq-to-sqlxml/index.md
@@ -11,7 +11,7 @@ I’m hacking along on my Document DB emulator ontop of Sql Server XML columns.
 I have some decent Linq support in place now.  
 The following query:
 
-```
+```csharp
 var query = from order in orders
             //must have status shipped
             where order.Status >= OrderStatus.Shipped      
@@ -24,7 +24,7 @@ var query = from order in orders
 
 will yield the following Sql + XQuery to the Sql Server:
 
-```
+```sql
 select *
 from documents
 where CollectionName = 'Order'  and 

--- a/blog/2011-03-02-linq-to-sqlxml-projections/index.md
+++ b/blog/2011-03-02-linq-to-sqlxml-projections/index.md
@@ -10,7 +10,7 @@ I’ve managed to add projection support to my Linq to Sql Server Xml column imp
 
 Executing this Linq query:
 
-```
+```csharp
 var query = (from order in ctx.GetCollection().AsQueryable()
                 where order.OrderTotal > 100000000
                 where order.ShippingDate == null
@@ -26,7 +26,7 @@ var query = (from order in ctx.GetCollection().AsQueryable()
 
 Will yeild this Sql + XQuery:
 
-```
+```sql
 select top 5 Id,DocumentData.query(
 '<object type="dynamic">
  <state>

--- a/blog/2011-04-01-or-mapping-and-domain-query-optimizations/index.md
+++ b/blog/2011-04-01-or-mapping-and-domain-query-optimizations/index.md
@@ -11,7 +11,7 @@ You write object-oriented code and often forget about eventual performance probl
 
 Take this (somewhat naive) example:
 
-```
+```csharp
 class Customer
 {
    ...
@@ -52,7 +52,7 @@ Using an unit of work container such as [https://github.com/rogeralsing/Precio.I
 
 We can then rewrite the above code slightly:
 
-```
+```csharp
 class Customer
 {
    ...

--- a/blog/2011-04-14-async-ctp-first-impressions/index.md
+++ b/blog/2011-04-14-async-ctp-first-impressions/index.md
@@ -14,7 +14,7 @@ The SP1 Refresh can be found here: [http://msdn.microsoft.com/sv-se/vstudio/asyn
 The new async and await features makes async programming so much sweeter, it lets you write async code in a sequential manner.  
 e.g.
 
-```
+```csharp
 static async void ShowGoogleHtmlCode()
 {
   WebClient client = new WebClient();
@@ -31,7 +31,7 @@ However, there are some design considerations.
 
 Consider this:
 
-```
+```csharp
 public async void SetupUi()
 {
   var blogService = new BlogServiceClient();
@@ -46,7 +46,7 @@ public async void SetupUi()
 This code will call GetCategories and GetLatestPosts at the same time and then wait for \_both\_ of them to complete before continuing to fill the GUI elements.  
 If you are doing a Silverlight app, then you probably want to display each GUI element as soon as possible, and thus, the above code could be rewritten to:
 
-```
+```csharp
 public async void SetupUi()
 {
   SetupCategories();
@@ -72,7 +72,7 @@ This way, the async calls will be independent of each other and fill the corre
 
 Also, if you were to write the first code in this way:
 
-```
+```csharp
 public async void SetupUi()
 {
   var blogService = new BlogServiceClient();

--- a/blog/2011-04-14-consuming-wcf-services-in-silverlight-using-async-ctp/index.md
+++ b/blog/2011-04-14-consuming-wcf-services-in-silverlight-using-async-ctp/index.md
@@ -10,7 +10,7 @@ Here is a small sample of how you can consume WCF services using the new Async C
 
 **Example, filling a listbox with categories of some sort.**
 
-```
+```csharp
 private async void FillCategories()
 {
     var client = new MyServiceReference.MyServiceClient();

--- a/blog/2011-04-15-f-style-mailbox-agent-using-c-async-ctp/index.md
+++ b/blog/2011-04-15-f-style-mailbox-agent-using-c-async-ctp/index.md
@@ -10,7 +10,7 @@ More info on TPL DataFlow can be found here : [http://www.microsoft.com/download
 
 Here is a (naive) F# style Mailbox / Agent using the C# async CTP :
 
-```
+```csharp
     class Program
     {
         static void Main(string[] args)

--- a/blog/2011-04-15-fake-fibers-using-async-ctp/index.md
+++ b/blog/2011-04-15-fake-fibers-using-async-ctp/index.md
@@ -11,7 +11,7 @@ This is another PoC, building recursive code with continuations using the Async�
 The code creates a fake fiber, which can be suspended and resumed, thus allowing us to “step” through its actions.  
 This technique could be useful when building an interpreting language where you might want to step through the expressions.
 
-```
+```csharp
     using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/blog/2012-07-09-functional-ddd-in-f/index.md
+++ b/blog/2012-07-09-functional-ddd-in-f/index.md
@@ -12,7 +12,7 @@ I have to say I was sort of pleasantly surprised how well the entire concept wor
 
 This is only a spike on my part so don’t expect too much, but the code shows how Gregs ideas can be implemented using F#
 
-```
+```fsharp
 //state for order line items
 type LineItem =
     {

--- a/blog/2012-09-24-c-consume-non-async-apis-as-async/index.md
+++ b/blog/2012-09-24-c-consume-non-async-apis-as-async/index.md
@@ -13,7 +13,7 @@ You will be able to consume them *as if* they were async, and in some cases this
 
 The wrapper code provided here may still be a decent start for you to do this, since you can start migrating code to use async calls, while you rewrite the methods that need rewriting later.
 
-```
+```csharp
 
     class Program
     {

--- a/blog/2013-08-06-seo-indexing-angularjs-sites-or-other-ajax-sites-with-wombit-crawlr/index.md
+++ b/blog/2013-08-06-seo-indexing-angularjs-sites-or-other-ajax-sites-with-wombit-crawlr/index.md
@@ -29,7 +29,7 @@ This service will let you pass an url to it and get the dynamic content back as 
 
 In my site I do it like this, using MVC4:
 
-```
+```csharp
         public ActionResult Index()
         {
             string fragment = Request.QueryString["_escaped_fragment_"];

--- a/blog/2013-08-26-angularjs-directive-to-check-that-passwords-match-followup/index.md
+++ b/blog/2013-08-26-angularjs-directive-to-check-that-passwords-match-followup/index.md
@@ -14,7 +14,7 @@ I started out by using the directive that is described in his blogpost but later
 Bruno’s example relies on JQuery and DOM-event in order to do it’s magic, which does work fine, but for someone learning AngularJS it might not be the best example out there.  
 So here is my take on the very same directive:
 
-```
+```javascript
 app.directive('passwordMatch', [function () {
     return {
         restrict: 'A',
@@ -45,7 +45,7 @@ This works by comparing variables on the current scope instead of reading values
 
 Usage:
 
-```
+```html
 <input type="password"  
      ng-model="password2" 
      password-match="password1" />

--- a/blog/2013-12-01-why-mapping-dtos-to-entities-using-automapper-and-entityframework-is-horrible/index.md
+++ b/blog/2013-12-01-why-mapping-dtos-to-entities-using-automapper-and-entityframework-is-horrible/index.md
@@ -17,7 +17,7 @@ The scenario here is an Order service with an Order entity and an OrderDTO.
 
 Example code (pseudo code):
 
-```
+```csharp
  //entities
  class Order
      int Id //auto inc id
@@ -43,7 +43,7 @@ I’m pretty sure you have seen something similar to this before.
 
 Lets also assume there is some sort of service that updates orders:
 
-```
+```csharp
     public void CreateOrUpdateOrder(OrderDTO orderDTO)
     {
        ...
@@ -53,7 +53,7 @@ Lets also assume there is some sort of service that updates orders:
 So what do we need to do in order to make this work?  
 Maybe you do something like this:
 
-```
+```csharp
     public void CreateOrUpdateOrder(OrderDTO orderDTO)
     {
         //this code would probably reside somewhere else, 
@@ -80,7 +80,7 @@ So what can we do about this?
 
 Maybe we can do it like this?
 
-```
+```csharp
 public void CreateOrUpdateOrder(OrderDTO orderDTO)
 {
    //this code would probably reside somewhere else, 
@@ -116,7 +116,7 @@ So even if we can create and update the order entity, we are still messed up whe
 
 Lets try again:
 
-```
+```csharp
 public void CreateOrUpdateOrder(OrderDTO orderDTO)
 {
    var context = ... //get some DbContext
@@ -168,7 +168,7 @@ We have to delete those otherwise we will have a foreign key exception when call
 
 OK, so lets see what we can do about this:
 
-```
+```csharp
 public void CreateOrUpdateOrder(OrderDTO orderDTO)
 {
    var context = ... //get some DbContext
@@ -228,7 +228,7 @@ This code is not thread safe, if two requests arrive at the server at the same t
 
 AutoMapper’s static Mapper class is not threadsafe, we have to modify our code even further.
 
-```
+```csharp
 public void CreateOrUpdateOrder(OrderDTO orderDTO)
 {
    var config = new ...
@@ -302,7 +302,7 @@ e.g. in a Rest API using MongoDB or such, but that has little to do with the key
 One of the biggest pain points in this specific case is actually AutoMapper, I think AutoMapper is a great tool, just not for this specific usecase.  
 If we remove automapper from the equation here. we could end up with some code that looks like this:
 
-```
+```csharp
 public void CreateOrUpdateOrder(OrderDTO orderDTO)
 {
     var ctx = ... //get some DbContext

--- a/blog/2013-12-02-using-command-pattern-to-capture-language-and-intent-for-services/index.md
+++ b/blog/2013-12-02-using-command-pattern-to-capture-language-and-intent-for-services/index.md
@@ -17,7 +17,7 @@ I want to capture language and intent when modelling services, that is, I want t
 
 Let’s re-use the same scenario as we used in my previous post:
 
-```
+```csharp
 //entities
 class Order
     int Id //auto inc id
@@ -58,7 +58,7 @@ Your code might be small’ish, except for the weird change tracking replication
 Wouldn’t it be nice if we instead could capture valid state transitions and the domain experts language at the same time?  
 What if we do something like this:
 
-```
+```csharp
 public int PlaceNewOrder(){
     using (UoW.Begin())
     {
@@ -102,7 +102,7 @@ This is where command pattern comes in.
 
 Lets redesign our code to something along the lines of:
 
-```
+```csharp
 public static class OrderService
 {
     public static void Process(IEnumerable<command></command> commands)

--- a/blog/2014-01-01-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-01-pigeon-akka-actors-for-net/index.md
@@ -14,7 +14,7 @@ Git hub repository goes here: [https://github.com/rogeralsing/Pigeon](https://g
 
 **Write your first actor:**
 
-```
+```csharp
 public class Greet : IMessage
 {
     public string Who { get; set; }
@@ -32,7 +32,7 @@ public class GreetingActor : UntypedActor
 
 **Usage:**
 
-```
+```csharp
 var system = new ActorSystem();
 var greeter = system.ActorOf("greeter");
 greeter.Tell(new Greet { Who = "Roger" }, ActorRef.NoSender);
@@ -40,7 +40,7 @@ greeter.Tell(new Greet { Who = "Roger" }, ActorRef.NoSender);
 
 **Remoting support:**
 
-```
+```csharp
 //Server Program.CS
 var system = ActorSystemSignalR.Create("myserver", "http://localhost:8080);
 var greeter = system.ActorOf("greeter");
@@ -69,7 +69,7 @@ In Pigeon however, we have Async/Await support.
 
 You can async await responses from other actors like this:
 
-```
+```csharp
 
 //inside an actor
 var result = await Ask(someActor, messageToAsk);

--- a/blog/2014-01-03-hotswap-and-supervision-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-03-hotswap-and-supervision-pigeon-akka-actors-for-net/index.md
@@ -23,7 +23,7 @@ I’ve also added some more nifty features from Akka – Hotswap and Supervisio
 
 Like this:
 
-```
+```csharp
 public class GreetingActor : UntypedActor
 {
     protected override void OnReceive(IMessage message)
@@ -60,7 +60,7 @@ e.g. you can configure it to restart, restart or escalate if an exception of a g
 
 Like this:
 
-```
+```csharp
 public class MyActor : UntypedActor
 {
     private ActorRef logger = Context.ActorOf<LogActor>();

--- a/blog/2014-01-16-throughput-of-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-16-throughput-of-pigeon-akka-actors-for-net/index.md
@@ -16,7 +16,7 @@ Akka made some noise when they managed to process 50 million messages per second
 I’ve now ported this benchmark to Pigeon so that one can get a hint of how the two compares.  
 This is the results from an 8 core laptop:
 
-```
+```text
  Worker threads: 1023
  OSVersion: Microsoft Windows NT 6.2.9200.0
  ProcessorCount: 8
@@ -39,7 +39,7 @@ This is the results from an 8 core laptop:
 I’m pretty pleased with the performance so far.  
 The code for the benchmark actors looks like this:
 
-```
+```csharp
 private static object Msg = new object();
 private static object Run = new object();
 

--- a/blog/2014-01-26-3294/index.md
+++ b/blog/2014-01-26-3294/index.md
@@ -12,7 +12,7 @@ Trying to stay close to how Akka works, I decided to go for a Json based configu
 
 A config could look something like this:
 
-```
+```json
 Pigeon : {
     Actor : {
         Serializers : {
@@ -35,7 +35,7 @@ Pigeon : {
 
 Remoting is also treated as an extension to the ActorSystem, so there is no longer any awkward subclass, like this:
 
-```
+```csharp
 using (var system = ActorSystem.Create("MyClient",config,new RemoteExtension()))
 {
 ```

--- a/blog/2014-02-01-configuring-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-02-01-configuring-pigeon-akka-actors-for-net/index.md
@@ -12,7 +12,7 @@ So Pigeon now uses HOCON notation for the config files, and thus, allows for re-
 
 This means you can write configurations like:
 
-```
+```csharp
 var config = ConfigurationFactory.ParseString(@"
 # we use real Akka Hocon notation configs
 akka {

--- a/blog/2014-02-21-massive-improvements-to-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-02-21-massive-improvements-to-pigeon-akka-actors-for-net/index.md
@@ -16,7 +16,7 @@ We support the same features as real Akka, so logging can be done using the Acto
 We are also leveraging the real Akka config, so we can enable logging based on the same configuration options that Akka has.  
 Here is a snapshot of the output from the StandardOutLogger when booting the ChatServer example:
 
-```
+```text
 2014-02-21 22:40:44 DebugLevel EventStream - subscribing [akka://all-systems/StandardOutLogger] to channel Pigeon.Event.Info [Thread 9]
 2014-02-21 22:40:44 DebugLevel EventStream - subscribing [akka://all-systems/StandardOutLogger] to channel Pigeon.Event.Warning [Thread 9]
 2014-02-21 22:40:44 DebugLevel EventStream - subscribing [akka://all-systems/StandardOutLogger] to channel Pigeon.Event.Error [Thread 9]

--- a/blog/2014-03-09-deploying-actors-with-akka-net/index.md
+++ b/blog/2014-03-09-deploying-actors-with-akka-net/index.md
@@ -16,7 +16,7 @@ It might have one actor that deals with user input and another actor that does s
 
 It could look something like this:
 
-```
+```csharp
 var system = ActorSystem.Create("mysystem");
 var worker = system.ActorOf<WorkerActor>("worker");
 var userInput = system.ActorOf<UserInput>("userInput");
@@ -35,7 +35,7 @@ Instead of letting the user input actor know how many workers we have, we can in
 
 Router actors act as a facade on top of other actors, this means that the router can delegate incoming messages to a pool or group of underlying actors.
 
-```
+```csharp
 var system = ActorSystem.Create("mysystem");
 var worker1 = system.ActorOf<Worker>("worker1");
 var worker2 = system.ActorOf<Worker>("worker2");
@@ -58,7 +58,7 @@ We do not need to change any of the other code, as long as the user input actor 
 
 If we want to accomplish the same thing, but using a config instead, we can something like this:
 
-```
+```csharp
  var config = ConfigurationFactory.ParseString(@"
     akka.actor.deployment {
             /worker {
@@ -84,7 +84,7 @@ But what if this is still not enough?
 We might need to scale out also, and introduce more machines.  
 This can be done using “remote deployment”, like this:
 
-```
+```csharp
  var config = ConfigurationFactory.ParseString(@"
     akka.actor.deployment {
             /worker {

--- a/blog/2014-11-10-akka-net-concurrency-control/index.md
+++ b/blog/2014-11-10-akka-net-concurrency-control/index.md
@@ -24,7 +24,7 @@ Let’s say we need to model a bank account.
 That is a classic concurrency problem.  
 If we would use OOP, we might start with something like this:
 
-```
+```csharp
 public class BankAccount
 {
     private decimal _balance;
@@ -46,7 +46,7 @@ That seems fair, right?
 This will work fine in a single threaded environment where only one thread is accessing the above code.  
 But what happens when two or more competing threads are calling the same code?
 
-```
+```csharp
     public void Withdraw(decimal amount)
     {
         if (_balance < amount) //<-
@@ -57,7 +57,7 @@ That if-statement might be running in parallel on two or more theads, and at tha
 So in order to deal with this we need to introduce locks.  
 Maybe something like this:
 
-```
+```csharp
     private readonly object _lock = new object();
     private decimal _balance;
     public void Withdraw(decimal amount)
@@ -88,7 +88,7 @@ This still applies if there are multiple producers passing messages to the actor
 
 So let’s model the same problem using an Akka.NET actor:
 
-```
+```csharp
 
 //immutable message for withdraw:
 public class Withdraw
@@ -131,7 +131,7 @@ In the example code, I use strings as the response on the status of the operatio
 
 How do we use this code then?
 
-```
+```csharp
 
 ActorSystem system = ActorSystem.Create("mysystem");
 ...

--- a/blog/2014-12-17-learning-azure-day-1-servicebus/index.md
+++ b/blog/2014-12-17-learning-azure-day-1-servicebus/index.md
@@ -25,7 +25,7 @@ This was using a single threaded client, so maybe the difference is not that big
 
 And for those who are just looking for some example code, here it is:
 
-```
+```csharp
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/blog/2015-04-13-akka-net-azure-azure-servicebus-integration/index.md
+++ b/blog/2015-04-13-akka-net-azure-azure-servicebus-integration/index.md
@@ -26,7 +26,7 @@ As we haven’t acked the message to the service bus, the service bus will try t
 
 A simple implementation of this approach using Azure Service bus could look something like this:
 
-```
+```csharp
 namespace ConsoleApplication13
 {
     //define your worker actor

--- a/blog/2016-08-16-wire-writing-one-of-the-fastest-net-serializers/index.md
+++ b/blog/2016-08-16-wire-writing-one-of-the-fastest-net-serializers/index.md
@@ -14,7 +14,7 @@ Given the following POCO type.
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public class Poco
 {
    public string StringProp { get; set; }
@@ -67,7 +67,7 @@ Instead of having code like:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public ValueSerializer GetSerializerByType(Type type)
 {
   ValueSerializer serializer;
@@ -85,7 +85,7 @@ I turned the code into something like:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public ValueSerializer GetSerializerByType(Type type)
 {
   if (type == typeof(string))
@@ -108,7 +108,7 @@ Calls to `typeof()` actually generates a bit of IL code:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 ldtoken      [mscorlib]System.String
 call         class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
 ```
@@ -119,7 +119,7 @@ We can prevent these extra calls per type simply by storing references to each p
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public ValueSerializer GetSerializerByType(Type type)
 {
   if (ReferenceEquals(type.GetTypeInfo().Assembly, ReflectionEx.CoreAssembly))
@@ -175,7 +175,7 @@ For example, when deserializing a string, the code looked something like:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 //StringValueSerializer.cs
 public override object ReadValue(Stream stream)
 {
@@ -198,7 +198,7 @@ This allowed us to do something like this:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 //StringValueSerializer.cs
 public override object ReadValue(Stream stream, DeserializerSession session)
 {
@@ -229,7 +229,7 @@ This allowed us to go from code that looked like this:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 //Int64ValueSerializer.cs
 public override void WriteValue(Stream stream, object value)
 {
@@ -245,7 +245,7 @@ To something like this:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 //Int64ValueSerializer.cs
 public override void WriteValue(Stream stream, object value, SerializerSession session)
 {
@@ -296,7 +296,7 @@ Like this:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public class FastTypeUShortDictionary
 {
   private int _length; //this keeps track on how many types have been added
@@ -329,7 +329,7 @@ We let the value serializer emit its code using an `ICompiler` abstraction, like
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 public sealed override void EmitWriteValue(ICompiler<ObjectWriter> c, int stream, int fieldValue, int session)
 {
     var byteArray = c.GetVariable<byte[]>;(DefaultCodeGenerator.PreallocatedByteBuffer);
@@ -349,7 +349,7 @@ You can however extract this information:
 
 <div class="wp-block-syntaxhighlighter-code">
 
-```
+```csharp
 var defaultCtor = type.GetTypeInfo().GetConstructor(new Type[] {});
 var il = defaultCtor?.GetMethodBody()?.GetILAsByteArray();
 var sideEffectFreeCtor = il != null && il.Length <= 8; //this is the size of an empty ctor


### PR DESCRIPTION
## Summary
- add C# syntax identifiers to code examples across older blog posts so they highlight correctly
- tag other snippets (F#, JavaScript, SQL, HTML, JSON, text output) with appropriate languages for accurate rendering
- leave pure prose / DSL samples as plain text fences for clarity

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dbac66d2a88328a4cba44398071b96