### PR TITLE
Align blog tags with curated taxonomy

### DIFF
--- a/blog/2008-01-08-code-mangling-aop-vs-runtime-proxy-aop/index.md
+++ b/blog/2008-01-08-code-mangling-aop-vs-runtime-proxy-aop/index.md
@@ -1,8 +1,10 @@
 ---
 slug: code-mangling-aop-vs-runtime-proxy-aop
-title: "Code mangling AOP vs. Runtime Proxy AOP"
-authors: [rogerjohansson]
-tags: ["aspect-oriented-programming", "c", "naspect"]
+title: Code mangling AOP vs. Runtime Proxy AOP
+authors:
+- rogerjohansson
+tags:
+- aspect-oriented-programming
 ---
 <span> **THIS IS AN OLD POST FROM MY OLD BLOG (2006)**</span> 
 

--- a/blog/2008-01-08-naspect-the-first-debuggable-aop-framework-for-net/index.md
+++ b/blog/2008-01-08-naspect-the-first-debuggable-aop-framework-for-net/index.md
@@ -1,8 +1,10 @@
 ---
 slug: naspect-the-first-debuggable-aop-framework-for-net
-title: "NAspect – the first debuggable AOP framework for .NET"
-authors: [rogerjohansson]
-tags: ["aspect-oriented-programming", "debug-visualizer", "naspect"]
+title: "NAspect \u2013 the first debuggable AOP framework for .NET"
+authors:
+- rogerjohansson
+tags:
+- aspect-oriented-programming
 ---
 **THIS IS AN OLD POST FROM MY OLD BLOG (2006)**
 

--- a/blog/2008-01-08-query-objects-vs-dsl/index.md
+++ b/blog/2008-01-08-query-objects-vs-dsl/index.md
@@ -1,8 +1,10 @@
 ---
 slug: query-objects-vs-dsl
-title: "Query Objects vs. DSL"
-authors: [rogerjohansson]
-tags: ["domain-specific-languages", "npath", "npersist", "query-objects"]
+title: Query Objects vs. DSL
+authors:
+- rogerjohansson
+tags:
+- domain-specific-languages
 ---
 <span> **THIS IS AN OLD POST FROM MY OLD BLOG**</span> (2006)
 

--- a/blog/2008-01-09-orm-and-c3-anonymous-types/index.md
+++ b/blog/2008-01-09-orm-and-c3-anonymous-types/index.md
@@ -1,8 +1,11 @@
 ---
 slug: orm-and-c3-anonymous-types
-title: "ORM and C#3 anonymous types"
-authors: [rogerjohansson]
-tags: ["anonymous-types", "c", "linq", "o-r-mapping"]
+title: ORM and C#3 anonymous types
+authors:
+- rogerjohansson
+tags:
+- anonymous-types
+- linq
 ---
 <!-- truncate -->
 

--- a/blog/2008-01-10-making-a-custom-linq-engine/index.md
+++ b/blog/2008-01-10-making-a-custom-linq-engine/index.md
@@ -1,8 +1,10 @@
 ---
 slug: making-a-custom-linq-engine
-title: "Making a custom Linq engine"
-authors: [rogerjohansson]
-tags: ["c", "linq", "o-r-mapping"]
+title: Making a custom Linq engine
+authors:
+- rogerjohansson
+tags:
+- linq
 ---
 <!-- truncate -->
 

--- a/blog/2008-01-27-32/index.md
+++ b/blog/2008-01-27-32/index.md
@@ -1,8 +1,12 @@
 ---
 slug: 32
-title: "Lisp weekend"
-authors: [rogerjohansson]
-tags: ["c-lambda", "domain-specific-languages", "lisp", "net"]
+title: Lisp weekend
+authors:
+- rogerjohansson
+tags:
+- domain-specific-languages
+- lisp
+- net
 ---
 I’ve been reading up a bit on functional programming the last few week, the reason is just to comprehend the new features and possibilities in .NET 3.5 as much as possible.
 

--- a/blog/2008-01-30-lisp-debugger/index.md
+++ b/blog/2008-01-30-lisp-debugger/index.md
@@ -1,8 +1,12 @@
 ---
 slug: lisp-debugger
-title: "Lisp Debugger"
-authors: [rogerjohansson]
-tags: ["c", "debugger", "domain-specific-languages", "lisp", "net"]
+title: Lisp Debugger
+authors:
+- rogerjohansson
+tags:
+- domain-specific-languages
+- lisp
+- net
 ---
 I’m still working on my Lisp language clone.  
 Today I started to add debugging support to it.  

--- a/blog/2008-02-07-genetic-programming-math/index.md
+++ b/blog/2008-02-07-genetic-programming-math/index.md
@@ -1,8 +1,9 @@
 ---
 slug: genetic-programming-math
-title: "Genetic programming / Math"
-authors: [rogerjohansson]
-tags: ["c", "darwin", "evolution", "genetic-algorithms", "genetic-programming"]
+title: Genetic programming / Math
+authors:
+- rogerjohansson
+tags: []
 ---
 For those of you who are interested in evolution / GP.  
 Here is a small app that I made to reverse engineer blackboxed formulas.

--- a/blog/2008-02-08-mylisp-editor/index.md
+++ b/blog/2008-02-08-mylisp-editor/index.md
@@ -1,8 +1,10 @@
 ---
 slug: mylisp-editor
-title: "MyLisp Editor"
-authors: [rogerjohansson]
-tags: ["c", "lisp", "mylisp", "syntaxbox", "windows-forms"]
+title: MyLisp Editor
+authors:
+- rogerjohansson
+tags:
+- lisp
 ---
 I’ve started to make a very simple editor for MyLisp, just so I can get some highlighting and testrun my snippets.
 

--- a/blog/2008-02-08-optimizing-mylisp/index.md
+++ b/blog/2008-02-08-optimizing-mylisp/index.md
@@ -1,8 +1,11 @@
 ---
 slug: optimizing-mylisp
-title: "Optimizing MyLisp"
-authors: [rogerjohansson]
-tags: ["c", "l", "lisp", "mylisp", "optimizing"]
+title: Optimizing MyLisp
+authors:
+- rogerjohansson
+tags:
+- lisp
+- optimizing
 ---
 Today I stumbled across the weirdest thing.
 

--- a/blog/2008-02-09-npersist-updates/index.md
+++ b/blog/2008-02-09-npersist-updates/index.md
@@ -1,8 +1,10 @@
 ---
 slug: npersist-updates
-title: "NPersist updates"
-authors: [rogerjohansson]
-tags: ["npersist", "o-r-mapping", "puzzle"]
+title: NPersist updates
+authors:
+- rogerjohansson
+tags:
+- puzzle
 ---
 Mats just posted another of his dead sea scroll posts about the new features he have added to NPersist.  
 (Yes, while I have been slacking and playing with Lisp)

--- a/blog/2008-02-10-adding-linq-support-to-npersist/index.md
+++ b/blog/2008-02-10-adding-linq-support-to-npersist/index.md
@@ -1,8 +1,13 @@
 ---
 slug: adding-linq-support-to-npersist
-title: "Adding Linq support to NPersist"
-authors: [rogerjohansson]
-tags: ["c", "framework", "linq", "net", "o-r-mapping", "puzzle"]
+title: Adding Linq support to NPersist
+authors:
+- rogerjohansson
+tags:
+- framework
+- linq
+- net
+- puzzle
 ---
 I’m currently adding some real Linq support to NPersist.  
 I did start on it when the first public previews of Linq was released, but then I was kind of stuck in World of Warcraft for a while (OK, slightly more than a while).  

--- a/blog/2008-02-11-objectmapper-2008/index.md
+++ b/blog/2008-02-11-objectmapper-2008/index.md
@@ -1,8 +1,9 @@
 ---
 slug: objectmapper-2008
-title: "ObjectMapper 2008"
-authors: [rogerjohansson]
-tags: ["class-designer", "objectmapper", "puzzle-framework", "uml-editor", "whitehorse"]
+title: ObjectMapper 2008
+authors:
+- rogerjohansson
+tags: []
 ---
 [](http://rogeralsing.wordpress.com/wp-content/uploads/2008/02/classdesigner1.png "classdesigner1.png")The old ObjectMapper 2000 was and still is a great tool and I have used it in lots of projects to generate and map my entities.  
 But one thing that is clear, is that it was way way too complex for most users, it had more settings than the space shuttle and could be a real PITA in some cases.

--- a/blog/2008-02-12-dslisp/index.md
+++ b/blog/2008-02-12-dslisp/index.md
@@ -1,8 +1,11 @@
 ---
 slug: dslisp
-title: "DSLisp"
-authors: [rogerjohansson]
-tags: ["c", "domain-specific-languages", "dslisp", "net"]
+title: DSLisp
+authors:
+- rogerjohansson
+tags:
+- domain-specific-languages
+- net
 ---
 MyLisp is now named DSLisp – Domain Specific (Language) Lisp.
 

--- a/blog/2008-02-14-albinohorse/index.md
+++ b/blog/2008-02-14-albinohorse/index.md
@@ -1,8 +1,11 @@
 ---
 slug: albinohorse
-title: "AlbinoHorse – Class Designer"
-authors: [rogerjohansson]
-tags: ["c", "class-chart", "class-designer", "class-diagram", "diagramming", "net", "windows-forms"]
+title: "AlbinoHorse \u2013 Class Designer"
+authors:
+- rogerjohansson
+tags:
+- diagramming
+- net
 ---
 [](http://rogeralsing.wordpress.com/wp-content/uploads/2008/02/albinohorse.png "albinohorse.png")I have published my class designer component at CodePlex.
 

--- a/blog/2008-02-20-more-linq-support-for-npersist/index.md
+++ b/blog/2008-02-20-more-linq-support-for-npersist/index.md
@@ -1,8 +1,10 @@
 ---
 slug: more-linq-support-for-npersist
-title: "More Linq support for NPersist"
-authors: [rogerjohansson]
-tags: ["linq", "npath"]
+title: More Linq support for NPersist
+authors:
+- rogerjohansson
+tags:
+- linq
 ---
 I’ve added a bit more Linq support for NPersist today.
 

--- a/blog/2008-02-21-typed-factories-in-c3-managed-new/index.md
+++ b/blog/2008-02-21-typed-factories-in-c3-managed-new/index.md
@@ -1,8 +1,10 @@
 ---
 slug: typed-factories-in-c3-managed-new
-title: "Typed factories in C#3 – Managed “new”"
-authors: [rogerjohansson]
-tags: ["c", "design-patterns", "factory-methods", "managed-new"]
+title: "Typed factories in C#3 \u2013 Managed \u201Cnew\u201D"
+authors:
+- rogerjohansson
+tags:
+- design-patterns
 ---
 <!-- truncate -->
 

--- a/blog/2008-02-24-linq-to-npersist-to-ms-access/index.md
+++ b/blog/2008-02-24-linq-to-npersist-to-ms-access/index.md
@@ -1,8 +1,11 @@
 ---
 slug: linq-to-npersist-to-ms-access
-title: "Linq to NPersist to MS Access"
-authors: [rogerjohansson]
-tags: ["linq", "ms-access", "npersist", "sub-queries"]
+title: Linq to NPersist to MS Access
+authors:
+- rogerjohansson
+tags:
+- linq
+- sub-queries
 ---
 I’ve finally seen my own Linq support live 😛
 Until now I’ve only been emitting NPath queries and verified that NPath is correct.

--- a/blog/2008-02-26-linq-expressions-access-private-fields/index.md
+++ b/blog/2008-02-26-linq-expressions-access-private-fields/index.md
@@ -1,8 +1,12 @@
 ---
 slug: linq-expressions-access-private-fields
-title: "Linq Expressions – Access private fields"
-authors: [rogerjohansson]
-tags: ["delegates", "lambda", "linq", "linq-expressions"]
+title: "Linq Expressions \u2013 Access private fields"
+authors:
+- rogerjohansson
+tags:
+- delegates
+- lambda
+- linq
 ---
 In this post I will show how you can use Linq Expressions to access private (or public) class fields instead of using Reflection.FieldInfo.
 

--- a/blog/2008-02-27-linq-expressions-calculating-with-generics/index.md
+++ b/blog/2008-02-27-linq-expressions-calculating-with-generics/index.md
@@ -1,8 +1,12 @@
 ---
 slug: linq-expressions-calculating-with-generics
-title: "Linq Expressions – Calculating with generics"
-authors: [rogerjohansson]
-tags: ["delegates", "generic-algorithms", "generic-math", "lambda", "linq", "linq-expressions"]
+title: "Linq Expressions \u2013 Calculating with generics"
+authors:
+- rogerjohansson
+tags:
+- delegates
+- lambda
+- linq
 ---
 **You can find the full code for this post here:  **
 [**http://www.puzzleframework.com/Roger/GenericMath.cs.txt**](http://www.puzzleframework.com/Roger/GenericMath.cs.txt) 

--- a/blog/2008-02-28-linq-expressions-creating-objects/index.md
+++ b/blog/2008-02-28-linq-expressions-creating-objects/index.md
@@ -1,8 +1,12 @@
 ---
 slug: linq-expressions-creating-objects
-title: "Linq Expressions – Creating objects"
-authors: [rogerjohansson]
-tags: ["delegates", "lambda", "linq", "linq-expressions"]
+title: "Linq Expressions \u2013 Creating objects"
+authors:
+- rogerjohansson
+tags:
+- delegates
+- lambda
+- linq
 ---
 This post shows how you can use Linq expression trees to replace Activator.CreateInstance.
 

--- a/blog/2008-03-03-cil-compiler-construction/index.md
+++ b/blog/2008-03-03-cil-compiler-construction/index.md
@@ -1,8 +1,12 @@
 ---
 slug: cil-compiler-construction
-title: "CIL – Compiler construction"
-authors: [rogerjohansson]
-tags: ["cil", "compiler-construction", "compilers", "emit", "gold-parser", "msil", "reflection"]
+title: "CIL \u2013 Compiler construction"
+authors:
+- rogerjohansson
+tags:
+- compilers
+- gold-parser
+- reflection
 ---
 I’ve created a little sample on how to make your own .NET compiler.  
 The compiler uses Gold parser for parsing and Reflection.Emit to generate the compiled .exe file.

--- a/blog/2008-03-11-hidden-gem-buildmanagergettype/index.md
+++ b/blog/2008-03-11-hidden-gem-buildmanagergettype/index.md
@@ -1,8 +1,10 @@
 ---
 slug: hidden-gem-buildmanagergettype
-title: "Hidden gem: BuildManager.GetType"
-authors: [rogerjohansson]
-tags: ["asp-net", "c", "objectdatasource", "type-gettype", "type-names"]
+title: 'Hidden gem: BuildManager.GetType'
+authors:
+- rogerjohansson
+tags:
+- asp-net
 ---
 I’ve been digging through the ObjectDataSource today and I was trying to figure out how they created the datasource instance from the type name.
 

--- a/blog/2008-03-31-linq-to-objects-for-net-2-available/index.md
+++ b/blog/2008-03-31-linq-to-objects-for-net-2-available/index.md
@@ -1,8 +1,11 @@
 ---
 slug: linq-to-objects-for-net-2-available
-title: "Linq to objects for .NET 2 available"
-authors: [rogerjohansson]
-tags: ["delegate", "lambda", "linq", "net2", "object-queries"]
+title: Linq to objects for .NET 2 available
+authors:
+- rogerjohansson
+tags:
+- lambda
+- linq
 ---
 Patrik Löwendahl blogged about using C#3 features in .NET 2 via VS.NET 2008 a few days ago:  
 [http://www.lowendahl.net/showShout.aspx?id=191](http://www.lowendahl.net/showShout.aspx?id=191)

--- a/blog/2008-04-09-caramel-code-generator/index.md
+++ b/blog/2008-04-09-caramel-code-generator/index.md
@@ -1,8 +1,11 @@
 ---
 slug: caramel-code-generator
-title: "Caramel – Code Generator"
-authors: [rogerjohansson]
-tags: ["caramel-code-generator", "code-generator", "codesmith", "mygeneration", "objectmapper", "scripts", "templates"]
+title: "Caramel \u2013 Code Generator"
+authors:
+- rogerjohansson
+tags:
+- scripts
+- templates
 ---
 As some of you might know, I’ve been working on a class designer ([Albino horse](http://rogeralsing.com/2008/02/14/albinohorse/)) off and on for a while now.
 

--- a/blog/2008-04-17-disposer-idisposable-and-template-pattern/index.md
+++ b/blog/2008-04-17-disposer-idisposable-and-template-pattern/index.md
@@ -1,8 +1,12 @@
 ---
 slug: disposer-idisposable-and-template-pattern
-title: "Disposer – IDisposable and Template pattern"
-authors: [rogerjohansson]
-tags: ["gdi", "idisposable", "template-method-pattern", "wrapper"]
+title: "Disposer \u2013 IDisposable and Template pattern"
+authors:
+- rogerjohansson
+tags:
+- gdi
+- idisposable
+- template-method-pattern
 ---
 I do a fair amount of GDI+ programming, and thus using a lot of IDisposable objects.  
 But I also use template or factory methods alot in my apps, and that doesnt work well with disposable objects

--- a/blog/2008-05-09-async-calls-fork/index.md
+++ b/blog/2008-05-09-async-calls-fork/index.md
@@ -1,8 +1,11 @@
 ---
 slug: async-calls-fork
-title: "Optimizing SOA Applications – C# Async Fork"
-authors: [rogerjohansson]
-tags: ["async", "fluent-interface", "fork", "threading", "threads"]
+title: "Optimizing SOA Applications \u2013 C# Async Fork"
+authors:
+- rogerjohansson
+tags:
+- async
+- threading
 ---
 \[Edit 2012-12-04\]  
 Nowdays, there is better paralell support built into .NET itself.  

--- a/blog/2008-05-10-followup-how-to-validate-a-methods-arguments/index.md
+++ b/blog/2008-05-10-followup-how-to-validate-a-methods-arguments/index.md
@@ -1,8 +1,12 @@
 ---
 slug: followup-how-to-validate-a-methods-arguments
-title: "Followup: How to validate a method’s arguments?"
-authors: [rogerjohansson]
-tags: ["arguments", "extension-methods", "fluent-interface", "validation"]
+title: "Followup: How to validate a method\u2019s arguments?"
+authors:
+- rogerjohansson
+tags:
+- arguments
+- extension-methods
+- validation
 ---
 A few days ago I and Fredrik Normén had a discussion about argument validation here: [http://weblogs.asp.net/fredriknormen/archive/2008/05/08/how-to-validate-a-method-s-arguments.aspx](http://weblogs.asp.net/fredriknormen/archive/2008/05/08/how-to-validate-a-method-s-arguments.aspx)
 

--- a/blog/2008-06-09-syntaxbox-20/index.md
+++ b/blog/2008-06-09-syntaxbox-20/index.md
@@ -1,8 +1,11 @@
 ---
 slug: syntaxbox-20
-title: "SyntaxBox 2.0"
-authors: [rogerjohansson]
-tags: ["compona-syntaxbox", "parsing", "puzzle-syntaxbox", "syntax-highlight", "syntaxbox"]
+title: SyntaxBox 2.0
+authors:
+- rogerjohansson
+tags:
+- parsing
+- syntax-highlight
 ---
 Due to public request I am now kicking some life into my old **SyntaxBox** component again.  
 The code base have been upgraded to C#3 and compiles for .NET 2.0 (using VS.NET2008)

--- a/blog/2008-06-19-book-compiler-principles-the-red-dragon-book/index.md
+++ b/blog/2008-06-19-book-compiler-principles-the-red-dragon-book/index.md
@@ -1,8 +1,11 @@
 ---
 slug: book-compiler-principles-the-red-dragon-book
-title: "Book – Compiler principles… (The red dragon book)"
-authors: [rogerjohansson]
-tags: ["ast", "book", "compilers", "language"]
+title: "Book \u2013 Compiler principles\u2026 (The red dragon book)"
+authors:
+- rogerjohansson
+tags:
+- compilers
+- language
 ---
 Parsing and languages have always been one of my main interests when it comes to programming.  
 So a few weeks ago I decided to buy the “red dragon book” from Amazon.com.  

--- a/blog/2008-06-19-caramel-alpha-source-code-is-public/index.md
+++ b/blog/2008-06-19-caramel-alpha-source-code-is-public/index.md
@@ -1,8 +1,12 @@
 ---
 slug: caramel-alpha-source-code-is-public
-title: "Caramel – Alpha source code is public"
-authors: [rogerjohansson]
-tags: ["c", "caramel", "code-generation", "domain-specific-languages", "o-r-mapping", "orm"]
+title: "Caramel \u2013 Alpha source code is public"
+authors:
+- rogerjohansson
+tags:
+- code-generation
+- domain-specific-languages
+- orm
 ---
 I have added the Caramel code generator to my public repository at google code.  
 [http://code.google.com/p/alsing/](http://code.google.com/p/alsing/)

--- a/blog/2008-07-14-robus-xml-serialization/index.md
+++ b/blog/2008-07-14-robus-xml-serialization/index.md
@@ -1,8 +1,14 @@
 ---
 slug: robus-xml-serialization
-title: "Robust XML Serialization"
-authors: [rogerjohansson]
-tags: ["deserialization", "deserializer", "generics", "serialization", "serializer", "soap", "xml"]
+title: Robust XML Serialization
+authors:
+- rogerjohansson
+tags:
+- deserialization
+- generics
+- serialization
+- soap
+- xml
 ---
 OK, I’ve had it with the serializers in .NET.  
 All of them are lacking atleast some features that I need.

--- a/blog/2008-08-09-lambda-expressions-are-not-delegates/index.md
+++ b/blog/2008-08-09-lambda-expressions-are-not-delegates/index.md
@@ -1,8 +1,11 @@
 ---
 slug: lambda-expressions-are-not-delegates
-title: "Lambda expressions are not delegates"
-authors: [rogerjohansson]
-tags: ["delegates", "linq", "linq-expressions"]
+title: Lambda expressions are not delegates
+authors:
+- rogerjohansson
+tags:
+- delegates
+- linq
 ---
 There is allot of confusion gotesing on in the .NET community when it comes to Lambda expressions.  
 Allot of blog posts out there claiming that Lambdas are simply another way to write delegates, or rather anonymous delegates.

--- a/blog/2008-10-03-nworkspace-linq-workspace-followup/index.md
+++ b/blog/2008-10-03-nworkspace-linq-workspace-followup/index.md
@@ -1,8 +1,11 @@
 ---
 slug: nworkspace-linq-workspace-followup
-title: "NWorkspace / Linq Workspace Followup"
-authors: [rogerjohansson]
-tags: ["ddd", "linq", "nworkspace"]
+title: NWorkspace / Linq Workspace Followup
+authors:
+- rogerjohansson
+tags:
+- ddd
+- linq
 ---
 I’m still playing around with the outcome my [Linq Workspace Experiment](http://rogeralsing.com/2008/07/03/ddd-nworkspace-experiment/).
 

--- a/blog/2008-11-02-the-importance-of-domain-modelling/index.md
+++ b/blog/2008-11-02-the-importance-of-domain-modelling/index.md
@@ -1,8 +1,10 @@
 ---
 slug: the-importance-of-domain-modelling
-title: "The importance of domain modelling"
-authors: [rogerjohansson]
-tags: ["identity", "life", "pdc"]
+title: The importance of domain modelling
+authors:
+- rogerjohansson
+tags:
+- identity
 ---
 I’m going to dedicate this post for my somewhat unpleasant experience with the US security controls when going to the PDC 🙂
 

--- a/blog/2008-11-03-linq-expressions-assign-private-fields-c-4/index.md
+++ b/blog/2008-11-03-linq-expressions-assign-private-fields-c-4/index.md
@@ -1,8 +1,10 @@
 ---
 slug: linq-expressions-assign-private-fields-c-4
-title: "Linq Expressions: Assign private fields (.NET 4)"
-authors: [rogerjohansson]
-tags: ["dlr", "private-fields", "reflection"]
+title: 'Linq Expressions: Assign private fields (.NET 4)'
+authors:
+- rogerjohansson
+tags:
+- reflection
 ---
 **Hold your horses, you might not see this untill 2010**
 

--- a/blog/2008-11-10-m-grammar-vs-gold-parser/index.md
+++ b/blog/2008-11-10-m-grammar-vs-gold-parser/index.md
@@ -1,8 +1,11 @@
 ---
 slug: m-grammar-vs-gold-parser
-title: "M Grammar Vs. Gold Parser"
-authors: [rogerjohansson]
-tags: ["gold-parser", "m-grammar", "oslo", "parsers"]
+title: M Grammar Vs. Gold Parser
+authors:
+- rogerjohansson
+tags:
+- gold-parser
+- oslo
 ---
 Even though I bashed M Grammar in my [last post](http://rogeralsing.com/2008/11/04/i-call-bs-on-the-oslo-m-language/), I’m sort of starting to get what the fuzz is all about now.
 

--- a/blog/2009-01-04-scaling-clustere-evolution-1-1-4/index.md
+++ b/blog/2009-01-04-scaling-clustere-evolution-1-1-4/index.md
@@ -1,8 +1,10 @@
 ---
 slug: scaling-clustere-evolution-1-1-4
-title: "Scaling Clustered Evolution: 1 + 1 = 4"
-authors: [rogerjohansson]
-tags: ["cluster", "ga", "gp", "mpi"]
+title: 'Scaling Clustered Evolution: 1 + 1 = 4'
+authors:
+- rogerjohansson
+tags:
+- ga
 ---
 **This is a follow up on:** [**http://rogeralsing.com/2009/01/01/clustering-evolution-we-have-lift-off/**](http://rogeralsing.com/2009/01/01/clustering-evolution-we-have-lift-off/)
 

--- a/blog/2009-06-25-composite-oriented-programming-qi4j-running-on-net/index.md
+++ b/blog/2009-06-25-composite-oriented-programming-qi4j-running-on-net/index.md
@@ -1,8 +1,11 @@
 ---
 slug: composite-oriented-programming-qi4j-running-on-net
-title: "Composite Oriented Programming: QI4J running on .NET"
-authors: [rogerjohansson]
-tags: ["composite-oriented-programming", "cop", "qi4j"]
+title: 'Composite Oriented Programming: QI4J running on .NET'
+authors:
+- rogerjohansson
+tags:
+- composite-oriented-programming
+- cop
 ---
 For the last month I have been spending my spare time porting the awesome Java framework QI4J to .NET.  
 QI4J is the brain child of Rickard Öberg and Niclas Hedhman and it attempts to enable Composite Oriented Programming for the Java platform.  

--- a/blog/2009-12-27-f-pipelining-in-c/index.md
+++ b/blog/2009-12-27-f-pipelining-in-c/index.md
@@ -1,8 +1,9 @@
 ---
 slug: f-pipelining-in-c
-title: "F# Pipelining in C#"
-authors: [rogerjohansson]
-tags: ["f"]
+title: F# Pipelining in C#
+authors:
+- rogerjohansson
+tags: []
 ---
 Here is one such example where F# developers try to make it look like F# can do things that C# can not.
 

--- a/blog/2009-12-27-i-still-dont-get-f/index.md
+++ b/blog/2009-12-27-i-still-dont-get-f/index.md
@@ -1,8 +1,9 @@
 ---
 slug: i-still-dont-get-f
-title: "I still don’t get F#"
-authors: [rogerjohansson]
-tags: ["f"]
+title: "I still don\u2019t get F#"
+authors:
+- rogerjohansson
+tags: []
 ---
 I think that Microsoft are trying to sell F# to us as something new and awesome, but I’m having serious problems seeing the benefits over C#.
 

--- a/blog/2009-12-29-massive-parallelism-f-in-the-cloud/index.md
+++ b/blog/2009-12-29-massive-parallelism-f-in-the-cloud/index.md
@@ -1,8 +1,10 @@
 ---
 slug: massive-parallelism-f-in-the-cloud
-title: "Massive parallelism – F# in the cloud?"
-authors: [rogerjohansson]
-tags: ["cloud", "f", "parallelism"]
+title: "Massive parallelism \u2013 F# in the cloud?"
+authors:
+- rogerjohansson
+tags:
+- parallelism
 ---
 I’m still trying to learn a bit of F# and I thought of a quite nice experiment.  
 Since F# supports quotations (for you C# devs, think Linq Expressions on roids) wouldn’t it be possible to serialize such quotation and pass it to a webservice and execute that code there?

--- a/blog/2010-03-23-generic-dsl-grammar-and-parser/index.md
+++ b/blog/2010-03-23-generic-dsl-grammar-and-parser/index.md
@@ -1,8 +1,11 @@
 ---
 slug: generic-dsl-grammar-and-parser
-title: "Generic DSL Grammar and Parser"
-authors: [rogerjohansson]
-tags: ["ast", "dsl", "gold-parser", "intentional"]
+title: Generic DSL Grammar and Parser
+authors:
+- rogerjohansson
+tags:
+- gold-parser
+- intentional
 ---
 About a year ago I blogged about an idea of an extensible language; [http://rogeralsing.com/2009/03/18/an-intentional-extensible-language/](http://rogeralsing.com/2009/03/18/an-intentional-extensible-language/)   
 Since then, I have been experimenting with this concept quite a bit.

--- a/blog/2010-03-26-f-gold-parser-true/index.md
+++ b/blog/2010-03-26-f-gold-parser-true/index.md
@@ -1,8 +1,11 @@
 ---
 slug: f-gold-parser-true
-title: "F# + Gold Parser = true"
-authors: [rogerjohansson]
-tags: ["ast", "dsl", "f", "gold-parser", "parsing"]
+title: F# + Gold Parser = true
+authors:
+- rogerjohansson
+tags:
+- gold-parser
+- parsing
 ---
 First of all, I have to confess that I’ve started to see the light of F# and AST manipulation.
 

--- a/blog/2010-03-26-generic-dsl-using-f/index.md
+++ b/blog/2010-03-26-generic-dsl-using-f/index.md
@@ -1,8 +1,10 @@
 ---
 slug: generic-dsl-using-f
-title: "Generic DSL using F#"
-authors: [rogerjohansson]
-tags: ["ast", "dsl", "parsing"]
+title: Generic DSL using F#
+authors:
+- rogerjohansson
+tags:
+- parsing
 ---
 A few days ago I announced that I was working on a generic DSL parser : [http://rogeralsing.com/2010/03/23/generic-dsl-grammar-and-parser/](http://rogeralsing.com/2010/03/23/generic-dsl-grammar-and-parser/)  
 I’m now porting the code to F# since it is more suited for AST traversal.

--- a/blog/2010-03-28-vs2010-theme-netbeans-clone/index.md
+++ b/blog/2010-03-28-vs2010-theme-netbeans-clone/index.md
@@ -1,8 +1,10 @@
 ---
 slug: vs2010-theme-netbeans-clone
-title: "VS2010 Theme – Netbeans clone"
-authors: [rogerjohansson]
-tags: ["netbeans", "theme", "vs-net"]
+title: "VS2010 Theme \u2013 Netbeans clone"
+authors:
+- rogerjohansson
+tags:
+- theme
 ---
 I’ve replicated my favorite Netbeans theme “Norway Today” to VS.NET 2010,  
 I think it the dark blue bg works quite well with the blue VS2010 design.

--- a/blog/2010-07-29-evolutionary-algorithms-problems-with-directed-evolution/index.md
+++ b/blog/2010-07-29-evolutionary-algorithms-problems-with-directed-evolution/index.md
@@ -1,8 +1,10 @@
 ---
 slug: evolutionary-algorithms-problems-with-directed-evolution
-title: "Evolutionary Algorithms – Problems with Directed Evolution"
-authors: [rogerjohansson]
-tags: ["darwin", "dawkins", "ea", "ga"]
+title: "Evolutionary Algorithms \u2013 Problems with Directed Evolution"
+authors:
+- rogerjohansson
+tags:
+- ga
 ---
 Creationists often use “irreducible complexity” as an argument against evolution.  
 e.g. you need all parts in place and functioning before the “whole” can do its work and thus reproduce and spread its features.

--- a/blog/2010-07-30-evolutionary-algorithms-directing-the-undirected/index.md
+++ b/blog/2010-07-30-evolutionary-algorithms-directing-the-undirected/index.md
@@ -1,8 +1,10 @@
 ---
 slug: evolutionary-algorithms-directing-the-undirected
-title: "Evolutionary Algorithms – Directing the undirected"
-authors: [rogerjohansson]
-tags: ["darwin", "dawkins", "ea", "ga", "gp"]
+title: "Evolutionary Algorithms \u2013 Directing the undirected"
+authors:
+- rogerjohansson
+tags:
+- ga
 ---
 This is a followup to my previous post on the same topic : [http://rogeralsing.com/2010/07/29/evolutionary-algorithms-problems-with-directed-evolution/](http://rogeralsing.com/2010/07/29/evolutionary-algorithms-problems-with-directed-evolution/)
 

--- a/blog/2011-02-10-net-disassembled-part-2-for-loops/index.md
+++ b/blog/2011-02-10-net-disassembled-part-2-for-loops/index.md
@@ -1,8 +1,12 @@
 ---
 slug: net-disassembled-part-2-for-loops
-title: ".NET disassembled Part 2: for loops"
-authors: [rogerjohansson]
-tags: ["forloop", "jit", "native", "x86"]
+title: '.NET disassembled Part 2: for loops'
+authors:
+- rogerjohansson
+tags:
+- jit
+- native
+- x86
 ---
 **.NET Disassembled**  
 Part 1: [integers in .NET](http://rogeralsing.com/2011/02/05/integers-in-net/)  

--- a/blog/2011-02-27-building-a-document-db-ontop-of-sql-server/index.md
+++ b/blog/2011-02-27-building-a-document-db-ontop-of-sql-server/index.md
@@ -1,8 +1,9 @@
 ---
 slug: building-a-document-db-ontop-of-sql-server
-title: "Building a Document DB on Top of SQL Server"
-authors: [rogerjohansson]
-tags: ["documentdb", "mongodb", "ravendb", "xml-columns"]
+title: Building a Document DB on Top of SQL Server
+authors:
+- rogerjohansson
+tags: []
 ---
 I’ve started to build a Document DB emulator on top of SQL Server XML columns.
 SQL Server XML columns can store schema-free XML documents, pretty much like RavenDB or MongoDB stores schema-free JSON/BSON documents.

--- a/blog/2011-02-28-linq-to-sqlxml/index.md
+++ b/blog/2011-02-28-linq-to-sqlxml/index.md
@@ -1,8 +1,11 @@
 ---
 slug: linq-to-sqlxml
-title: "Linq to SqlXML"
-authors: [rogerjohansson]
-tags: ["documentdb", "sql-server", "xml", "xpath", "xquery"]
+title: Linq to SqlXML
+authors:
+- rogerjohansson
+tags:
+- sql-server
+- xml
 ---
 I’m hacking along on my Document DB emulator ontop of Sql Server XML columns.
 

--- a/blog/2011-03-02-linq-to-sqlxml-github/index.md
+++ b/blog/2011-03-02-linq-to-sqlxml-github/index.md
@@ -1,8 +1,11 @@
 ---
 slug: linq-to-sqlxml-github
-title: "Linq to SqlXml – GitHub"
-authors: [rogerjohansson]
-tags: ["documentdb", "mongodb", "nosql", "ravendb", "xml", "xquery"]
+title: "Linq to SqlXml \u2013 GitHub"
+authors:
+- rogerjohansson
+tags:
+- nosql
+- xml
 ---
 An early alpha of Linq to SqlXml is now available on github: [https://github.com/calyptus/linq-to-sqlxml](https://github.com/calyptus/linq-to-sqlxml)
 

--- a/blog/2011-04-01-or-mapping-and-domain-query-optimizations/index.md
+++ b/blog/2011-04-01-or-mapping-and-domain-query-optimizations/index.md
@@ -1,8 +1,10 @@
 ---
 slug: or-mapping-and-domain-query-optimizations
-title: "O/R Mapping and domain query optimizations"
-authors: [rogerjohansson]
-tags: ["ddd", "ef4"]
+title: O/R Mapping and domain query optimizations
+authors:
+- rogerjohansson
+tags:
+- ddd
 ---
 One of the cons of O/R mapping is that the abstraction is a bit too high.  
 You write object-oriented code and often forget about eventual performance problems.

--- a/blog/2013-08-06-seo-indexing-angularjs-sites-or-other-ajax-sites-with-wombit-crawlr/index.md
+++ b/blog/2013-08-06-seo-indexing-angularjs-sites-or-other-ajax-sites-with-wombit-crawlr/index.md
@@ -1,8 +1,11 @@
 ---
 slug: seo-indexing-angularjs-sites-or-other-ajax-sites-with-wombit-crawlr
-title: "SEO – Indexing AngularJS sites (or other ajax sites) with Wombit Crawlr"
-authors: [rogerjohansson]
-tags: ["ajax", "angularjs", "htmlsnapshot", "seo"]
+title: "SEO \u2013 Indexing AngularJS sites (or other ajax sites) with Wombit Crawlr"
+authors:
+- rogerjohansson
+tags:
+- ajax
+- seo
 ---
 Lately I have been diving deep into single page app development.  
 One specific problem that I never knew about before was that it is a true pain to make ajax sites crawlable.

--- a/blog/2013-11-29-ddd-prentity/index.md
+++ b/blog/2013-11-29-ddd-prentity/index.md
@@ -1,8 +1,10 @@
 ---
 slug: ddd-prentity
-title: "DDD – Prentity?"
-authors: [rogerjohansson]
-tags: ["cqrs", "entity"]
+title: "DDD \u2013 Prentity?"
+authors:
+- rogerjohansson
+tags:
+- cqrs
 ---
 This post is actually a question:
 

--- a/blog/2013-12-01-why-mapping-dtos-to-entities-using-automapper-and-entityframework-is-horrible/index.md
+++ b/blog/2013-12-01-why-mapping-dtos-to-entities-using-automapper-and-entityframework-is-horrible/index.md
@@ -1,8 +1,14 @@
 ---
 slug: why-mapping-dtos-to-entities-using-automapper-and-entityframework-is-horrible
-title: "Why mapping DTOs to Entities using AutoMapper and EntityFramework is horrible"
-authors: [rogerjohansson]
-tags: ["automapper", "cqrs", "datatransferobject", "ddd", "dto", "entities", "entityframework", "linq", "mapping"]
+title: Why mapping DTOs to Entities using AutoMapper and EntityFramework is horrible
+authors:
+- rogerjohansson
+tags:
+- cqrs
+- ddd
+- entityframework
+- linq
+- mapping
 ---
 One of the most common architectures for web apps right now is based on passing DataTransferObjects(DTOs) to and from CRUD services that updates your business/domain entities using tools like AutoMapper and EntityFramework.
 

--- a/blog/2014-01-01-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-01-pigeon-akka-actors-for-net/index.md
@@ -1,8 +1,10 @@
 ---
 slug: pigeon-akka-actors-for-net
-title: "Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "pigeon"]
+title: "Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
 ---
 I’m working on a port of the Java/Scala framework **Akka**, or rather the Actor Model part of it.  
 As of now, this is only a bit more than a weekend hack, so don’t expect too much.  

--- a/blog/2014-01-03-hotswap-and-supervision-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-03-hotswap-and-supervision-pigeon-akka-actors-for-net/index.md
@@ -1,8 +1,11 @@
 ---
 slug: hotswap-and-supervision-pigeon-akka-actors-for-net
-title: "Hotswap and Supervision – Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "async", "pigeon"]
+title: "Hotswap and Supervision \u2013 Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- async
 ---
 This is a follow up on my previous post; [http://rogeralsing.com/2014/01/01/pigeon-akka-actors-for-net/](http://rogeralsing.com/2014/01/01/pigeon-akka-actors-for-net/)
 

--- a/blog/2014-01-16-throughput-of-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-01-16-throughput-of-pigeon-akka-actors-for-net/index.md
@@ -1,8 +1,11 @@
 ---
 slug: throughput-of-pigeon-akka-actors-for-net
-title: "Throughput of Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "pigeon", "throughput"]
+title: "Throughput of Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- throughput
 ---
 As some of you might know, I’m making an unofficial port of Akka for .NET.  
 [https://github.com/rogeralsing/Pigeon](https://github.com/rogeralsing/Pigeon).  

--- a/blog/2014-01-26-3294/index.md
+++ b/blog/2014-01-26-3294/index.md
@@ -1,8 +1,10 @@
 ---
 slug: 3294
-title: "Configuration and Remote support for Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "pigeon"]
+title: "Configuration and Remote support for Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
 ---
 I’ve been working quite a bit on my Akka port this weekend.  
 Finally got a a configuration system in place.  

--- a/blog/2014-02-01-configuring-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-02-01-configuring-pigeon-akka-actors-for-net/index.md
@@ -1,8 +1,12 @@
 ---
 slug: configuring-pigeon-akka-actors-for-net
-title: "Configuring Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "hocon", "pigeon", "typesafe"]
+title: "Configuring Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- hocon
+- typesafe
 ---
 When I began to write the configuration support for my Akka Actors port “Pigeon”, I used JSON for the config files.  
 I’ve now managed to get some nice progress porting Typesafe’s Configuration library too.  

--- a/blog/2014-02-08-actor-lifecycle-management-and-routers-akka-actors-for-net/index.md
+++ b/blog/2014-02-08-actor-lifecycle-management-and-routers-akka-actors-for-net/index.md
@@ -1,8 +1,12 @@
 ---
 slug: actor-lifecycle-management-and-routers-akka-actors-for-net
-title: "Actor lifecycle management and routers – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "routing", "supervision"]
+title: "Actor lifecycle management and routers \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- routing
+- supervision
 ---
 ## Porting Akka to .NET
 

--- a/blog/2014-02-21-massive-improvements-to-pigeon-akka-actors-for-net/index.md
+++ b/blog/2014-02-21-massive-improvements-to-pigeon-akka-actors-for-net/index.md
@@ -1,8 +1,11 @@
 ---
 slug: massive-improvements-to-pigeon-akka-actors-for-net
-title: "Massive improvements to Pigeon – Akka Actors for .NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "net", "pigeon"]
+title: "Massive improvements to Pigeon \u2013 Akka Actors for .NET"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- net
 ---
 The last few weeks have been busy busy.  
 Me and [Aaron](http://www.aaronstannard.com/) have been making some massive improvements to Pigeon.  

--- a/blog/2014-03-05-introducing-akka-net/index.md
+++ b/blog/2014-03-05-introducing-akka-net/index.md
@@ -1,8 +1,11 @@
 ---
 slug: introducing-akka-net
-title: "Introducing Akka.NET"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "akka-net", "async"]
+title: Introducing Akka.NET
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- async
 ---
 ![](./akkanet.png)
 

--- a/blog/2014-03-09-deploying-actors-with-akka-net/index.md
+++ b/blog/2014-03-09-deploying-actors-with-akka-net/index.md
@@ -1,8 +1,10 @@
 ---
 slug: deploying-actors-with-akka-net
-title: "Deploying actors with Akka.NET"
-authors: [rogerjohansson]
-tags: ["actors", "akka", "deployment", "remoting"]
+title: Deploying actors with Akka.NET
+authors:
+- rogerjohansson
+tags:
+- remoting
 ---
 We have now ported both the code and configuration based deployment features of Akka.  
 This means that you can now use Akka.NET to deploy actors and routers on remote nodes either via code or configuration.

--- a/blog/2014-11-10-akka-net-concurrency-control/index.md
+++ b/blog/2014-11-10-akka-net-concurrency-control/index.md
@@ -1,8 +1,11 @@
 ---
 slug: akka-net-concurrency-control
-title: "Akka.NET – Concurrency control"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "akka-net", "concurrency", "nethouse-se"]
+title: "Akka.NET \u2013 Concurrency control"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- concurrency
 ---
 Time to break the silence!
 

--- a/blog/2014-11-15-actor-based-distributed-transactions/index.md
+++ b/blog/2014-11-15-actor-based-distributed-transactions/index.md
@@ -1,8 +1,11 @@
 ---
 slug: actor-based-distributed-transactions
-title: "Actor based distributed transactions"
-authors: [rogerjohansson]
-tags: ["akka", "akka-net", "distributed-transactions", "msdtc", "transactions"]
+title: Actor based distributed transactions
+authors:
+- rogerjohansson
+tags:
+- distributed-transactions
+- transactions
 ---
 One question that often shows up when talking about the Actor Model, is how to deal with distributed transactions.
 

--- a/blog/2015-07-26-building-a-framework-the-early-akka-net-history/index.md
+++ b/blog/2015-07-26-building-a-framework-the-early-akka-net-history/index.md
@@ -1,8 +1,12 @@
 ---
 slug: building-a-framework-the-early-akka-net-history
-title: "Building a framework – The early Akka.NET history"
-authors: [rogerjohansson]
-tags: ["actor-model", "akka", "message-passing", "open-source"]
+title: "Building a framework \u2013 The early Akka.NET history"
+authors:
+- rogerjohansson
+tags:
+- actor-model
+- message-passing
+- open-source
 ---
 In this post, I will try to cover some of the early history of Akka.NET and how and why things turned out the way they did.  
 **Akka.NET of course have some parallel histories going as there are many contributors on the project.  

--- a/blog/2017-05-19-do-not-do-in-code-what-can-be-done-in-infrastructure/index.md
+++ b/blog/2017-05-19-do-not-do-in-code-what-can-be-done-in-infrastructure/index.md
@@ -1,8 +1,11 @@
 ---
 slug: do-not-do-in-code-what-can-be-done-in-infrastructure
-title: "Do not do in code what can be done in infrastructure"
-authors: [rogerjohansson]
-tags: ["akka", "akka-net", "distributed-programming", "infrastructure", "microsoft-orleans"]
+title: Do not do in code what can be done in infrastructure
+authors:
+- rogerjohansson
+tags:
+- distributed-programming
+- infrastructure
 ---
 Or subtitle: *Maybe distributed programming is no longer a programming problem?* (For the obvious impaired: This is meant to be more thought provoking than an actual truth)
 

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -1,19 +1,374 @@
-facebook:
-  label: Facebook
-  permalink: /facebook
-  description: Facebook tag description
+actor-model:
+  label: Actor Model
+  permalink: /actor-model
+  description: Posts tagged with Actor Model.
 
-hello:
-  label: Hello
-  permalink: /hello
-  description: Hello tag description
+ajax:
+  label: Ajax
+  permalink: /ajax
+  description: Posts tagged with Ajax.
 
-docusaurus:
-  label: Docusaurus
-  permalink: /docusaurus
-  description: Docusaurus tag description
+anonymous-types:
+  label: Anonymous Types
+  permalink: /anonymous-types
+  description: Posts tagged with Anonymous Types.
 
-hola:
-  label: Hola
-  permalink: /hola
-  description: Hola tag description
+arguments:
+  label: Arguments
+  permalink: /arguments
+  description: Posts tagged with Arguments.
+
+asp-net:
+  label: Asp Net
+  permalink: /asp-net
+  description: Posts tagged with Asp Net.
+
+aspect-oriented-programming:
+  label: Aspect Oriented Programming
+  permalink: /aspect-oriented-programming
+  description: Posts tagged with Aspect Oriented Programming.
+
+async:
+  label: Async
+  permalink: /async
+  description: Posts tagged with Async.
+
+code-generation:
+  label: Code Generation
+  permalink: /code-generation
+  description: Posts tagged with Code Generation.
+
+compilers:
+  label: Compilers
+  permalink: /compilers
+  description: Posts tagged with Compilers.
+
+composite-oriented-programming:
+  label: Composite Oriented Programming
+  permalink: /composite-oriented-programming
+  description: Posts tagged with Composite Oriented Programming.
+
+concurrency:
+  label: Concurrency
+  permalink: /concurrency
+  description: Posts tagged with Concurrency.
+
+cop:
+  label: Cop
+  permalink: /cop
+  description: Posts tagged with Cop.
+
+cqrs:
+  label: Cqrs
+  permalink: /cqrs
+  description: Posts tagged with Cqrs.
+
+ddd:
+  label: Ddd
+  permalink: /ddd
+  description: Posts tagged with Ddd.
+
+delegates:
+  label: Delegates
+  permalink: /delegates
+  description: Posts tagged with Delegates.
+
+design-patterns:
+  label: Design Patterns
+  permalink: /design-patterns
+  description: Posts tagged with Design Patterns.
+
+deserialization:
+  label: Deserialization
+  permalink: /deserialization
+  description: Posts tagged with Deserialization.
+
+diagramming:
+  label: Diagramming
+  permalink: /diagramming
+  description: Posts tagged with Diagramming.
+
+distributed-programming:
+  label: Distributed Programming
+  permalink: /distributed-programming
+  description: Posts tagged with Distributed Programming.
+
+distributed-transactions:
+  label: Distributed Transactions
+  permalink: /distributed-transactions
+  description: Posts tagged with Distributed Transactions.
+
+domain-specific-languages:
+  label: Domain Specific Languages
+  permalink: /domain-specific-languages
+  description: Posts tagged with Domain Specific Languages.
+
+entityframework:
+  label: Entityframework
+  permalink: /entityframework
+  description: Posts tagged with Entityframework.
+
+extension-methods:
+  label: Extension Methods
+  permalink: /extension-methods
+  description: Posts tagged with Extension Methods.
+
+framework:
+  label: Framework
+  permalink: /framework
+  description: Posts tagged with Framework.
+
+ga:
+  label: Ga
+  permalink: /ga
+  description: Posts tagged with Ga.
+
+gdi:
+  label: Gdi
+  permalink: /gdi
+  description: Posts tagged with Gdi.
+
+generics:
+  label: Generics
+  permalink: /generics
+  description: Posts tagged with Generics.
+
+github:
+  label: Github
+  permalink: /github
+  description: Posts tagged with Github.
+
+gold-parser:
+  label: Gold Parser
+  permalink: /gold-parser
+  description: Posts tagged with Gold Parser.
+
+hocon:
+  label: Hocon
+  permalink: /hocon
+  description: Posts tagged with Hocon.
+
+identity:
+  label: Identity
+  permalink: /identity
+  description: Posts tagged with Identity.
+
+idisposable:
+  label: Idisposable
+  permalink: /idisposable
+  description: Posts tagged with Idisposable.
+
+infrastructure:
+  label: Infrastructure
+  permalink: /infrastructure
+  description: Posts tagged with Infrastructure.
+
+intentional:
+  label: Intentional
+  permalink: /intentional
+  description: Posts tagged with Intentional.
+
+jit:
+  label: Jit
+  permalink: /jit
+  description: Posts tagged with Jit.
+
+language:
+  label: Language
+  permalink: /language
+  description: Posts tagged with Language.
+
+lambda:
+  label: Lambda
+  permalink: /lambda
+  description: Posts tagged with Lambda.
+
+linq:
+  label: Linq
+  permalink: /linq
+  description: Posts tagged with Linq.
+
+lisp:
+  label: Lisp
+  permalink: /lisp
+  description: Posts tagged with Lisp.
+
+mapping:
+  label: Mapping
+  permalink: /mapping
+  description: Posts tagged with Mapping.
+
+memoization:
+  label: Memoization
+  permalink: /memoization
+  description: Posts tagged with Memoization.
+
+message-passing:
+  label: Message Passing
+  permalink: /message-passing
+  description: Posts tagged with Message Passing.
+
+native:
+  label: Native
+  permalink: /native
+  description: Posts tagged with Native.
+
+net:
+  label: Net
+  permalink: /net
+  description: Posts tagged with Net.
+
+nosql:
+  label: Nosql
+  permalink: /nosql
+  description: Posts tagged with Nosql.
+
+open-source:
+  label: Open Source
+  permalink: /open-source
+  description: Posts tagged with Open Source.
+
+optimizing:
+  label: Optimizing
+  permalink: /optimizing
+  description: Posts tagged with Optimizing.
+
+orm:
+  label: Orm
+  permalink: /orm
+  description: Posts tagged with Orm.
+
+oslo:
+  label: Oslo
+  permalink: /oslo
+  description: Posts tagged with Oslo.
+
+parallelism:
+  label: Parallelism
+  permalink: /parallelism
+  description: Posts tagged with Parallelism.
+
+parsing:
+  label: Parsing
+  permalink: /parsing
+  description: Posts tagged with Parsing.
+
+puzzle:
+  label: Puzzle
+  permalink: /puzzle
+  description: Posts tagged with Puzzle.
+
+reflection:
+  label: Reflection
+  permalink: /reflection
+  description: Posts tagged with Reflection.
+
+remoting:
+  label: Remoting
+  permalink: /remoting
+  description: Posts tagged with Remoting.
+
+routing:
+  label: Routing
+  permalink: /routing
+  description: Posts tagged with Routing.
+
+scripts:
+  label: Scripts
+  permalink: /scripts
+  description: Posts tagged with Scripts.
+
+seo:
+  label: Seo
+  permalink: /seo
+  description: Posts tagged with Seo.
+
+serialization:
+  label: Serialization
+  permalink: /serialization
+  description: Posts tagged with Serialization.
+
+servicebus:
+  label: Servicebus
+  permalink: /servicebus
+  description: Posts tagged with Servicebus.
+
+soap:
+  label: Soap
+  permalink: /soap
+  description: Posts tagged with Soap.
+
+sql-server:
+  label: Sql Server
+  permalink: /sql-server
+  description: Posts tagged with Sql Server.
+
+stateful:
+  label: Stateful
+  permalink: /stateful
+  description: Posts tagged with Stateful.
+
+sub-queries:
+  label: Sub Queries
+  permalink: /sub-queries
+  description: Posts tagged with Sub Queries.
+
+supervision:
+  label: Supervision
+  permalink: /supervision
+  description: Posts tagged with Supervision.
+
+syntax-highlight:
+  label: Syntax Highlight
+  permalink: /syntax-highlight
+  description: Posts tagged with Syntax Highlight.
+
+templates:
+  label: Templates
+  permalink: /templates
+  description: Posts tagged with Templates.
+
+template-method-pattern:
+  label: Template Method Pattern
+  permalink: /template-method-pattern
+  description: Posts tagged with Template Method Pattern.
+
+theme:
+  label: Theme
+  permalink: /theme
+  description: Posts tagged with Theme.
+
+threading:
+  label: Threading
+  permalink: /threading
+  description: Posts tagged with Threading.
+
+throughput:
+  label: Throughput
+  permalink: /throughput
+  description: Posts tagged with Throughput.
+
+transactions:
+  label: Transactions
+  permalink: /transactions
+  description: Posts tagged with Transactions.
+
+typesafe:
+  label: Typesafe
+  permalink: /typesafe
+  description: Posts tagged with Typesafe.
+
+validation:
+  label: Validation
+  permalink: /validation
+  description: Posts tagged with Validation.
+
+x86:
+  label: X86
+  permalink: /x86
+  description: Posts tagged with X86.
+
+xml:
+  label: Xml
+  permalink: /xml
+  description: Posts tagged with Xml.


### PR DESCRIPTION
## Summary
- replace the placeholder tag definitions with the curated documentation taxonomy
- limit each blog post to the tags that exist in the new tag catalog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcf7645b88328a5c11d79ec732f95