### PR TITLE
Add Go examples across Proto.Actor guides

### DIFF
--- a/docs/ProtoActor/ask-pattern.md
+++ b/docs/ProtoActor/ask-pattern.md
@@ -24,6 +24,16 @@ In Proto.Actor you can use `Context.Request` when the sender expects the recipie
 var response = await pid.RequestAsync<MyReply>(new MyRequest());
 ```
 
+```go
+future := system.Root.RequestFuture(pid, &MyRequest{}, time.Second)
+response, err := future.Result()
+if err != nil {
+        logger.Error("request failed", "err", err)
+        return
+}
+reply := response.(*MyReply)
+```
+
 ## When to Use
 - Querying another actor for state or service results.
 - Bridging between actor code and external await-based APIs.
@@ -64,6 +74,20 @@ public class Counter : IActor
         }
         return Task.CompletedTask;
     }
+}
+```
+
+```go
+type Counter struct {
+        value int
+}
+
+func (c *Counter) Receive(context actor.Context) {
+        switch context.Message().(type) {
+        case *Increment:
+                c.value++
+                context.ActorSystem().EventStream.Publish(&CountChanged{Value: c.value})
+        }
 }
 ```
 

--- a/docs/ProtoActor/asyncsemaphore.md
+++ b/docs/ProtoActor/asyncsemaphore.md
@@ -31,6 +31,10 @@ var res =
 
 ```
 
+```go
+//TODO: missing
+```
+
 :::warning
 The `AsyncSemaphore` only guards concurrency inside a single process.
 If your system uses scale-out, the semaphore will only guard calls within the process on each instance.

--- a/docs/ProtoActor/circuit-breaker.md
+++ b/docs/ProtoActor/circuit-breaker.md
@@ -189,6 +189,10 @@ var breakerPid = system.Root.Spawn(Props.FromProducer(() =>
 var reply = await system.Root.RequestAsync<MyReply>(breakerPid, new MyRequest(), TimeSpan.FromSeconds(5));
 ```
 
+```go
+//TODO: missing
+```
+
 This sample returns `ServiceUnavailable` when the circuit is open or a call fails. For
 production scenarios consider adding metrics, logging, or retry policies to improve resilience.
 
@@ -338,6 +342,10 @@ var targetProps = Props
 var targetPid = system.Root.Spawn(targetProps);
 
 var reply = await system.Root.RequestAsync<MyReply>(targetPid, new MyRequest(), TimeSpan.FromSeconds(5));
+```
+
+```go
+//TODO: missing
 ```
 
 ## Tips

--- a/docs/ProtoActor/deadletter.md
+++ b/docs/ProtoActor/deadletter.md
@@ -72,9 +72,37 @@ static async Task Main(string[] args)
 }
 ```
 
+```go
+func main() {
+        system := actor.NewActorSystem()
+        props := actor.PropsFromProducer(func() actor.Actor { return &Echo{} })
+        pid := system.Root.Spawn(props)
+
+        subscription := system.EventStream.Subscribe(func(evt interface{}) {
+                if dl, ok := evt.(*actor.DeadLetterEvent); ok {
+                        fmt.Printf("Sender: %v, Pid: %v, Message: %v\n", dl.Sender, dl.PID, dl.Message)
+                }
+        })
+
+        system.Root.Send(pid, &TestMessage{})
+        system.Root.Poison(pid)
+        system.Root.Send(pid, &TestMessage{})
+
+        system.EventStream.Unsubscribe(subscription)
+}
+```
+
 Messages sent to a terminated actor cannot be processed and the PID on that actor must no longer be used. When messages are sent to a terminated actor, they are placed in the DeadLetter queue. This confirms receipt of the message by our handler.
 
 ```csharp
 system.EventStream.Subscribe<DeadLetterEvent>(msg =>
     Console.WriteLine($"Sender: {msg.Sender}, Pid: {msg.Pid}, Message: {msg.Message}"));
+```
+
+```go
+subscription := system.EventStream.Subscribe(func(evt interface{}) {
+        if dl, ok := evt.(*actor.DeadLetterEvent); ok {
+                fmt.Printf("Sender: %v, Pid: %v, Message: %v\n", dl.Sender, dl.PID, dl.Message)
+        }
+})
 ```

--- a/docs/ProtoActor/dispatchers.md
+++ b/docs/ProtoActor/dispatchers.md
@@ -45,6 +45,12 @@ var dispatcher = new ThreadPoolDispatcher(throughput = 100);
 var props = Props.FromProducer(() => new MyActor()).WithDispatcher(dispatcher);
 ```
 
+```go
+dispatcher := actor.NewDefaultDispatcher(100)
+props := actor.PropsFromProducer(func() actor.Actor { return &MyActor{} },
+        actor.WithDispatcher(dispatcher))
+```
+
 #### Built-in dispatchers
 
 Some dispatchers are available out-of-the-box for convenience.

--- a/docs/ProtoActor/eventstream.md
+++ b/docs/ProtoActor/eventstream.md
@@ -40,10 +40,22 @@ orderSubscription = Cluster.System.EventStream.Subscribe<Order>(msg =>
     Console.WriteLine("message received"))
 ```
 
+```go
+orderSubscription := system.EventStream.Subscribe(func(evt interface{}) {
+        if msg, ok := evt.(*Order); ok {
+                fmt.Println("message received", msg)
+        }
+})
+```
+
 When the subscription is no longer necessary, for example, when the gift campaign is over, you can use `Unsubscribe` method. In this example, we have canceled the subscription of the GiftModule component, and after calling this method, the actor will stop receiving Order messages.
 
 ```csharp
 orderSubscription.Unsubscribe()
+```
+
+```go
+system.EventStream.Unsubscribe(orderSubscription)
 ```
 
 It is all that is required to subscribe GiftModule component to receive Order messages. After calling the `Subscribe` method, the GiftModule component will be receiving all Order messages published in EventStream. This method can be invoked for any actor that is interested in receiving Order messages. And when an actor needs to receive messages of different types, the `Subscribe` method can be called several times with varying kinds of messages.
@@ -52,6 +64,10 @@ Publishing messages in EventStream is as easy as that; just call the Publish met
 
 ```csharp
 system.EventStream.Publish(msg);
+```
+
+```go
+system.EventStream.Publish(msg)
 ```
 
 After that, the msg message will be passed to all subscribed actors. In fact, this completes description of the realization of channels like "publisher/subscriber" in Proto.Actor.

--- a/docs/ProtoActor/middleware.md
+++ b/docs/ProtoActor/middleware.md
@@ -35,6 +35,25 @@ var props = Actor.FromFunc(c => {
 
 ```
 
+```go
+props := actor.PropsFromFunc(func(ctx actor.Context) {
+        fmt.Println("actor")
+}, actor.WithReceiverMiddleware(
+        func(next actor.ReceiverFunc) actor.ReceiverFunc {
+                return func(ctx actor.ReceiverContext, envelope *actor.MessageEnvelope) {
+                        fmt.Println("middleware 1")
+                        next(ctx, envelope)
+                }
+        },
+        func(next actor.ReceiverFunc) actor.ReceiverFunc {
+                return func(ctx actor.ReceiverContext, envelope *actor.MessageEnvelope) {
+                        fmt.Println("middleware 2")
+                        next(ctx, envelope)
+                }
+        },
+))
+```
+
 The above code will print `middleware 1`, then `middleware 2`, then `actor`. The `next` argument to the first middleware will be the second middleware, and the `next` argument to the second middleware will be the actor's `Receive` method.
 
 ## Sender middleware
@@ -63,6 +82,25 @@ var props = Actor.FromFunc(c => {
         }
     );
 
+```
+
+```go
+props := actor.PropsFromFunc(func(ctx actor.Context) {
+        fmt.Println("actor")
+}, actor.WithSenderMiddleware(
+        func(next actor.SenderFunc) actor.SenderFunc {
+                return func(ctx actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {
+                        fmt.Println("middleware 1")
+                        next(ctx, target, envelope)
+                }
+        },
+        func(next actor.SenderFunc) actor.SenderFunc {
+                return func(ctx actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {
+                        fmt.Println("middleware 2")
+                        next(ctx, target, envelope)
+                }
+        },
+))
 ```
 
 The above code will print `actor`, then `middleware 1`, then `middleware 2`. The `next` argument to the first middleware will be the second middleware, and the `next` argument to the second middleware.

--- a/docs/ProtoActor/observability-cookbook.md
+++ b/docs/ProtoActor/observability-cookbook.md
@@ -17,6 +17,12 @@ Include correlation IDs to link logs to traces.
 log.LogInformation("{CorrelationId} handling {Message}", id, msg);
 ```
 
+```go
+logger.Info("handling message",
+    slog.String("correlation_id", id),
+    slog.Any("message", msg))
+```
+
 ## Metrics to watch
 
 - Mailbox depth per actor

--- a/docs/ProtoActor/persistence.md
+++ b/docs/ProtoActor/persistence.md
@@ -45,6 +45,10 @@ public delegate Task PersistRoomState(RoomState roomState);
 
 ```
 
+```go
+//TODO: missing
+```
+
 Both delegates might be injected in the actor's constructor. Then on actor's start, state is loaded.
 
 ``` csharp
@@ -74,6 +78,10 @@ Both delegates might be injected in the actor's constructor. Then on actor's sta
 
 ```
 
+```go
+//TODO: missing
+```
+
 After applying any change on actor's state, the second delegate is used and the state of actor is persisted.
 
 ```csharp
@@ -99,6 +107,10 @@ After applying any change on actor's state, the second delegate is used and the 
 
 ```
 
+```go
+//TODO: missing
+```
+
 ## Batched Persistence
 
 Batched persistence groups several persistence operations before writing them to the underlying
@@ -114,6 +126,10 @@ graph LR
 ```csharp
 var props = Props.FromProducer(() => new MyPersistentActor())
     .WithPersistence(new BatchingPersistence(batchSize: 50));
+```
+
+```go
+//TODO: missing
 ```
 
 At the time of writing there is no Go implementation for batched persistence.

--- a/docs/ProtoActor/spawn.md
+++ b/docs/ProtoActor/spawn.md
@@ -21,6 +21,13 @@ var pid2 = system.Root.SpawnPrefix(props, "prefix"); // spawn an actor with a pr
 var pid3 = system.Root.SpawnNamed(props, "my-actor"); // spawn an actor with an exact name
 ```
 
+```go
+system := actor.NewActorSystem()
+pid1 := system.Root.Spawn(props)                  // spawn an actor with an auto-generated name
+pid2 := system.Root.SpawnPrefix(props, "prefix") // spawn an actor with a prefix followed by an auto-generated name
+pid3 := system.Root.SpawnNamed(props, "my-actor")// spawn an actor with an exact name
+```
+
 :::note
 If an actor already exists with the specified name, this will throw a `ProcessNameExistException`.
 :::
@@ -33,5 +40,16 @@ public Task ReceiveAsync(IContext context)
     var pid1 = context.Spawn(props);
     var pid2 = context.SpawnPrefix(props, "prefix");
     var pid3 = context.SpawnNamed(props, "my-actor");
+}
+```
+
+```go
+func (state *MyActor) Receive(context actor.Context) {
+        pid1 := context.Spawn(props)
+        pid2 := context.SpawnPrefix(props, "prefix")
+        pid3 := context.SpawnNamed(props, "my-actor")
+        _ = pid1
+        _ = pid2
+        _ = pid3
 }
 ```

--- a/docs/ProtoActor/throttle.md
+++ b/docs/ProtoActor/throttle.md
@@ -19,16 +19,22 @@ private readonly ShouldThrottle _shouldThrottle;
 
 /* ... */
 
-_shouldThrottle = Throttle.Create( 
+_shouldThrottle = Throttle.Create(
     // max number of events/calls
     10,
-    
+
     // in this duration
     TimeSpan.FromSeconds(5),
-    
+
     // callback for when valve opens back up again
     count => _logger.LogInformation("Throttled {LogCount} logs for component xyz", count)
 );
+```
+
+```go
+shouldThrottle := actor.NewThrottle(10, 5*time.Second, func(throttled int32) {
+        logger.Info("Throttled logs", slog.Int("count", int(throttled)))
+})
 ```
 
 Usage:
@@ -38,6 +44,16 @@ catch(Exception e)
 {
     if (_shouldThrottle().IsOpen()) //if the valve of the throttle is open, log the event
         _logger.LogError(e, "Some operation failed");
+}
+```
+
+```go
+shouldThrottle := actor.NewThrottle(10, 5*time.Second, func(throttled int32) {
+        logger.Info("Throttled logs", slog.Int("count", int(throttled)))
+})
+
+if shouldThrottle() == actor.Open {
+        logger.Error("Some operation failed")
 }
 ```
 


### PR DESCRIPTION
## Summary
- add Go counterparts to the existing C# snippets in core Proto.Actor guides covering props, spawning, messaging, scheduling, middleware, dispatchers, observability, and throttling
- surface gaps where Go equivalents are unavailable by adding TODO placeholders to persistence, circuit breaker, and async semaphore docs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbd8120fe08328b1b558ba1fa958a6