### PR TITLE
Fix intro doc product links

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,7 +19,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/protoactor-logo.png" alt="Proto.Actor logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./ProtoActor/index.md">Proto.Actor</a> is our flagship actor framework for .NET and Go. It gives you a lightweight, cloud-native runtime for building resilient, distributed systems with message-driven actors, virtual actors, and cluster support. Explore the getting started guide, core concepts, and advanced modules like persistence, clustering, and testing utilities.</p>
+      <p><a href="/docs/ProtoActor/">Proto.Actor</a> is our flagship actor framework for .NET and Go. It gives you a lightweight, cloud-native runtime for building resilient, distributed systems with message-driven actors, virtual actors, and cluster support. Explore the getting started guide, core concepts, and advanced modules like persistence, clustering, and testing utilities.</p>
     </td>
   </tr>
 </table>
@@ -32,7 +32,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/durable-functions-logo.svg" alt="Durable Functions logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./DurableFunctions/index.md">Asynkron Durable Functions</a> lets you build long-running, reliable workflows in any .NET application using the durable orchestrator model. Start with the getting started guide, then dive into hosting guidance, orchestration patterns, and the operations handbook to ship resilient automation in production.</p>
+      <p><a href="/docs/DurableFunctions/">Asynkron Durable Functions</a> lets you build long-running, reliable workflows in any .NET application using the durable orchestrator model. Start with the getting started guide, then dive into hosting guidance, orchestration patterns, and the operations handbook to ship resilient automation in production.</p>
     </td>
   </tr>
 </table>
@@ -45,7 +45,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/fake-logo4.png" alt="LiveView placeholder logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./LiveView/index.md">Asynkron LiveView</a> brings real-time, reactive UI updates to your applications with a lightweight server-driven model inspired by LiveView frameworks. Learn how to set up the runtime, compose interactive components, and deploy to production.</p>
+      <p><a href="/docs/LiveView/">Asynkron LiveView</a> brings real-time, reactive UI updates to your applications with a lightweight server-driven model inspired by LiveView frameworks. Learn how to set up the runtime, compose interactive components, and deploy to production.</p>
     </td>
   </tr>
 </table>
@@ -58,7 +58,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/tracelens-logo.png" alt="TraceLens logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./TraceLens/index.md">TraceLens</a> provides observability tooling tailored for distributed actor systems. Use the guides to ingest telemetry, visualize actor flows, and troubleshoot live systems with minimal overhead.</p>
+      <p><a href="/docs/TraceLens/">TraceLens</a> provides observability tooling tailored for distributed actor systems. Use the guides to ingest telemetry, visualize actor flows, and troubleshoot live systems with minimal overhead.</p>
     </td>
   </tr>
 </table>
@@ -71,7 +71,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/fake-logo1.png" alt="OtelMcp placeholder logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./OtelMcp/index.md">Asynkron.OtelMcp</a> fuses an OpenTelemetry collector, search engine, and MCP interface so AI systems can interpret signals in real time. Spin it up to let copilots query telemetry, trigger automations, and surface insights across your distributed services.</p>
+      <p><a href="/docs/OtelMcp/">Asynkron.OtelMcp</a> fuses an OpenTelemetry collector, search engine, and MCP interface so AI systems can interpret signals in real time. Spin it up to let copilots query telemetry, trigger automations, and surface insights across your distributed services.</p>
     </td>
   </tr>
 </table>
@@ -84,7 +84,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/ocpp-server.png" alt="OcppServer logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./OcppServer/index.md">Asynkron.OcppServer</a> delivers an OCPP 1.6 Central System tuned for fleets with hundreds of thousands of concurrent chargers. Learn how to onboard devices, keep firmware current, and integrate billing and energy-market workflows.</p>
+      <p><a href="/docs/OcppServer/">Asynkron.OcppServer</a> delivers an OCPP 1.6 Central System tuned for fleets with hundreds of thousands of concurrent chargers. Learn how to onboard devices, keep firmware current, and integrate billing and energy-market workflows.</p>
     </td>
   </tr>
 </table>
@@ -97,7 +97,7 @@ Asynkron is a team of distributed-systems veterans who have spent the last decad
       <img src="/img/jsome-logo.png" alt="Jsome logo" width="120" />
     </td>
     <td valign="top">
-      <p><a href="./Jsome/index.md">Asynkron.Jsome</a> is a .NET global tool that generates strongly typed clients and schema artefacts from Swagger/OpenAPI or JSON Schema sources. Follow the docs to install the CLI, configure templates, and automate DTOs, validators, Protocol Buffers, and more as part of your build pipeline.</p>
+      <p><a href="/docs/Jsome/">Asynkron.Jsome</a> is a .NET global tool that generates strongly typed clients and schema artefacts from Swagger/OpenAPI or JSON Schema sources. Follow the docs to install the CLI, configure templates, and automate DTOs, validators, Protocol Buffers, and more as part of your build pipeline.</p>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- update the intro product cards to link to the correct documentation routes so each tile opens its section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbf23e297883289bdb130bf5effc8d