### PR TITLE
Add supplemental diagrams to DTO blog and supervision docs

### DIFF
--- a/docs/ProtoActor/behaviors.md
+++ b/docs/ProtoActor/behaviors.md
@@ -11,6 +11,28 @@ Actors can change their behavior at any time. This is achieved through the Behav
 
 We're going to use the example of modelling a light bulb to demonstrate this:
 
+```mermaid
+stateDiagram-v2
+    [*] --> Off
+    Off --> On: PressSwitch
+    On --> Off: PressSwitch
+    Off --> Off: Touch / "Cold"
+    On --> On: Touch / "Hot!"
+    Off --> Smashed: HitWithHammer
+    On --> Smashed: HitWithHammer
+    Smashed --> Off: ReplaceBulb
+```
+
+The state diagram mirrors the sample code so readers can match the textual handlers with concrete transitions.
+
+:::tip Project tip example
+Need hands-on samples? Browse the Proto.Actor .NET examples and Proto.Actor Go examples.
+:::
+
+:::note Reference
+Remember that our style guide has the canonical guidance for tone and terminology.
+:::
+
 ```csharp
 public class LightBulb : IActor
 {


### PR DESCRIPTION
## Summary
- add DTO versus entity structure and failure flow diagrams to the DTO mapping blog while tightening spelling
- add a light bulb state diagram plus style and sample references to the behaviors guide
- expand the fault tolerance guide with failure-handling sequence and flow visuals alongside maintenance callouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf60114dc8328950f8e0b450c6985