### PR TITLE
Add TraceLens logs tab image to overview page

### DIFF
--- a/docs/TraceLens/index.md
+++ b/docs/TraceLens/index.md
@@ -6,6 +6,8 @@ title: TraceLens
 
 # TraceLens
 
+![TraceLens logs tab](https://asynkron.se/assets/images/logs-tab-c6141e6354bfa3fc2adfd3f938021364.png)
+
 TraceLens is an OpenTelemetry-focused tracing and logging visualizer that also ships with a built-in collector so you can ingest and inspect telemetry from one container. It is published as a beta and is currently free for all users; after the beta concludes it will remain free for personal and open-source projects while commercial use is expected to require a subscription. Because the product is still in beta, the End User License Agreement highlights that the software is provided “as is” and forbids reverse engineering or derivative works.
 
 :::tip Project links

--- a/docs/TraceLens/index.md
+++ b/docs/TraceLens/index.md
@@ -6,7 +6,7 @@ title: TraceLens
 
 # TraceLens
 
-![TraceLens logs tab](https://asynkron.se/assets/images/logs-tab-c6141e6354bfa3fc2adfd3f938021364.png)
+![TraceLens logs tab](/static/img/tracelens/logs-tab.png)
 
 TraceLens is an OpenTelemetry-focused tracing and logging visualizer that also ships with a built-in collector so you can ingest and inspect telemetry from one container. It is published as a beta and is currently free for all users; after the beta concludes it will remain free for personal and open-source projects while commercial use is expected to require a subscription. Because the product is still in beta, the End User License Agreement highlights that the software is provided “as is” and forbids reverse engineering or derivative works.
 


### PR DESCRIPTION
## Summary
- embed the TraceLens logs tab screenshot at the top of the overview page to highlight the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb55e2c688328932e210078a64eb8